### PR TITLE
Renaming variables to be consistent across the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![PyPI](https://img.shields.io/pypi/v/py-ewr)](https://pypi.org/project/py-ewr/)
 [![DOI](https://zenodo.org/badge/342122359.svg)](https://zenodo.org/badge/latestdoi/342122359)
 
-### **EWR tool version 2.3.7 README**
+### **ewr tool version 2.3.7 README**
 
 ### **Notes on recent version updates**
 - Including metadata report (this is still being ironed out and tested)
 - CLLMM_c and CLLMM_d ewrs are now able to be calculated without all barrage level gauges being present in the model file. 
 - Including draft objective mapping files in the package (see below sub heading **Objective mapping** for more information). Objective mapping has been therefore pulled out of the parameter sheet
-- Including an example parallel processing script for running the EWR tool
+- Including an example parallel processing script for running the ewr tool
 - Adding handling for cases where there are single MDBA bigmod site IDs mapping to multiple different gauges
 - Fix SDL resource unit mapping in the parameter sheet
 - Adding lat and lon to the parameter sheet
@@ -37,7 +37,7 @@ pip install py-ewr
 ``` 
 
 ### Option 1: Running the observed mode of the tool
-The EWR tool will use a second program called gauge getter to first download the river data at the locations and dates selected and then run this through the EWR tool
+The ewr tool will use a second program called gauge getter to first download the river data at the locations and dates selected and then run this through the ewr tool
 
 ```python
 
@@ -58,14 +58,14 @@ gauges = ['Gauge1', 'Gauge2']
 
 from py_ewr.observed_handling import ObservedHandler
 
-# Running the EWR tool:
+# Running the ewr tool:
 ewr_oh = ObservedHandler(gauges=gauges, dates=dates)
 
 # Generating tables:
-# Table 1: Summarised EWR results for the entire timeseries
+# Table 1: Summarised ewr results for the entire timeseries
 ewr_results = ewr_oh.get_ewr_results()
 
-# Table 2: Summarised EWR results, aggregated to water years:
+# Table 2: Summarised ewr results, aggregated to water years:
 yearly_ewr_results = ewr_oh.get_yearly_ewr_results()
 
 # Table 3: All events details regardless of duration 
@@ -82,7 +82,7 @@ all_successful_interEvents = ewr_oh.get_all_successful_interEvents()
 
 ```
 
-### Option 2: Running model scenarios through the EWR tool
+### Option 2: Running model scenarios through the ewr tool
 
 1. Tell the tool where the model files are (can either be local or in a remote location)
 2. Tell the tool what format the model files are in. The current model format options are: 
@@ -143,15 +143,15 @@ for scenario_name, scenario_list in scenarios.items():
     all_successful_interEvents = pd.DataFrame()
     for file in scenarios[scenario_name]:
 
-        # Running the EWR tool:
+        # Running the ewr tool:
         ewr_sh = ScenarioHandler(scenario_file = file, 
                                 model_format = model_format)
 
         # Return each table and stitch the different files of the same scenario together:
-        # Table 1: Summarised EWR results for the entire timeseries
+        # Table 1: Summarised ewr results for the entire timeseries
         temp_ewr_results = ewr_sh.get_ewr_results()
         ewr_results = pd.concat([ewr_results, temp_ewr_results], axis = 0)
-        # Table 2: Summarised EWR results, aggregated to water years:
+        # Table 2: Summarised ewr results, aggregated to water years:
         temp_yearly_ewr_results = ewr_sh.get_yearly_ewr_results()
         yearly_ewr_results = pd.concat([yearly_ewr_results, temp_yearly_ewr_results], axis = 0)
         # Table 3: All events details regardless of duration 
@@ -190,15 +190,15 @@ for scenario_name, scenario_list in scenarios.items():
 
 ### **Purpose**
 This tool has two purposes:
-1. Operational: Tracking EWR success at gauges of interest in real time - option 1 above.
-2. Planning: Comparing EWR success between scenarios (i.e. model runs) - option 2 above.
+1. Operational: Tracking ewr success at gauges of interest in real time - option 1 above.
+2. Planning: Comparing ewr success between scenarios (i.e. model runs) - option 2 above.
 
 **Support**
 For issues relating to the script, a tutorial, or feedback please contact Lara Palmer at lara.palmer@mdba.gov.au, Martin Job at martin.job@mdba.gov.au, or Joel Bailey at joel.bailey@mdba.gov.au
 
 
 **Disclaimer**
-Every effort has been taken to ensure the EWR database represents the original EWRs from state Long Term Water Plans (LTWPs) and Environmental Water Management Plans (EWMPs) as best as possible, and that the code within this tool has been developed to interpret and analyse these EWRs in an accurate way. However, there may still be unresolved bugs in the EWR parameter sheet and/or EWR tool. Please report any bugs to the issues tab under the GitHub project so we can investigate further. 
+Every effort has been taken to ensure the ewr database represents the original EWRs from state Long Term Water Plans (LTWPs) and Environmental Water Management Plans (EWMPs) as best as possible, and that the code within this tool has been developed to interpret and analyse these EWRs in an accurate way. However, there may still be unresolved bugs in the ewr parameter sheet and/or ewr tool. Please report any bugs to the issues tab under the GitHub project so we can investigate further. 
 
 
 **Notes on development of the dataset of EWRs**
@@ -212,21 +212,21 @@ NSW:
 - All South Australian catchments
 - All EWRs from river based Environmental Water Management Plans (EWMPs) in Victoria*
 
-*Currently the wetland EWMPS and mixed wetland-river EWMPs in Victoria contain EWRs that cannot be evaluated by an automated EWR tool so the EWRs from these plans have been left out for now. The MDBA will work with our Victorian colleagues to ensure any updated EWRs in these plans are integrated into the tool where possible.
+*Currently the wetland EWMPS and mixed wetland-river EWMPs in Victoria contain EWRs that cannot be evaluated by an automated ewr tool so the EWRs from these plans have been left out for now. The MDBA will work with our Victorian colleagues to ensure any updated EWRs in these plans are integrated into the tool where possible.
 
 **Input data**
 
 - Gauge data from the relevant Basin state websites and the Bureau of Meteorology website
 - Scenario data input by the user
 - Model metadata for location association between gauge ID's and model nodes
-- EWR parameter sheet
+- ewr parameter sheet
 
 **Running the tool**
 
 Consult the user manual for instructions on how to run the tool. Please email the above email addresses for a copy of the user manual.
 
 **Objective mapping**
-Objective mapping csv files are now included in the EWR tool package. Currently this objective mapping is in an early draft format. The objective mapping will be finalised after consultation with relevant state representatives. The files are intended to be used together to link EWRs to the detailed objectives, theme level targets and specific goals. The three sheets are located in the py_ewr/parameter_metadata folder:
+Objective mapping csv files are now included in the ewr tool package. Currently this objective mapping is in an early draft format. The objective mapping will be finalised after consultation with relevant state representatives. The files are intended to be used together to link EWRs to the detailed objectives, theme level targets and specific goals. The three sheets are located in the py_ewr/parameter_metadata folder:
 - ewr2obj.csv: For each planning unit, gauge, ewr combination there are either one or many env_obj codes. These env_obj codes come under one of five different theme level targets (Native Fish, Native vegetation, Waterbirds, Other species or Ecosystem functions)
 - obj2target.csv: env_obj's are unique to their planning unit in the LTWP (noting there are often a lot of similarities between env_obj's in the same states). The plain english wording of the env objectives is also contained in this csv. The LTWP, planning unit and env_obj rows are repeated for each specific goal related to that LTWP, planning unit and env_obj. 
 - obj2yrtarget.csv: The environmental objectives are related to 5, 10 and 20 year targets

--- a/example_parallel_run.py
+++ b/example_parallel_run.py
@@ -4,7 +4,7 @@ import os
 
 from py_ewr.scenario_handling import ScenarioHandler
 
-#####--------------------- DEFINE EWR TOOL RUN FUCTION -------------------------#####
+#####--------------------- DEFINE ewr TOOL RUN FUCTION -------------------------#####
 
 def run_EWR_tool(
         scenario_name,
@@ -20,14 +20,14 @@ def run_EWR_tool(
     all_successful_interEvents = pd.DataFrame()
 
     for file in scenario_files:
-        # Running the EWR tool:
+        # Running the ewr tool:
         ewr_sh = ScenarioHandler(scenario_file=file, model_format=model_format)
 
         # Return each table and stitch the different files of the same scenario together:
-        # Table 1: Summarised EWR results for the entire timeseries
+        # Table 1: Summarised ewr results for the entire timeseries
         temp_ewr_results = ewr_sh.get_ewr_results()
         ewr_results = pd.concat([ewr_results, temp_ewr_results], axis=0)
-        # Table 2: Summarised EWR results, aggregated to water years:
+        # Table 2: Summarised ewr results, aggregated to water years:
         temp_yearly_ewr_results = ewr_sh.get_yearly_ewr_results()
         yearly_ewr_results = pd.concat(
             [yearly_ewr_results, temp_yearly_ewr_results], axis=0

--- a/py_ewr/data_inputs.py
+++ b/py_ewr/data_inputs.py
@@ -152,7 +152,7 @@ def get_components_map() -> dict:
     components_map = {
         'PlanningUnitID': 'planning_unit',
         'Gauge': 'Gauge',
-        'Code': 'EWR_code',
+        'Code': 'Code',
         'FlowThresholdMin': 'min_flow',
         'FlowThresholdMax': 'max_flow',
         'VolumeThreshold': 'min_volume',

--- a/py_ewr/data_inputs.py
+++ b/py_ewr/data_inputs.py
@@ -150,7 +150,7 @@ def get_EWR_table(file_path:str = None) -> dict:
 
 def get_components_map() -> dict:
     components_map = {
-        'PlanningUnitID': 'planning_unit',
+        'PlanningUnitID': 'PlanningUnit',
         'Gauge': 'Gauge',
         'Code': 'Code',
         'FlowThresholdMin': 'min_flow',

--- a/py_ewr/data_inputs.py
+++ b/py_ewr/data_inputs.py
@@ -151,7 +151,7 @@ def get_EWR_table(file_path:str = None) -> dict:
 def get_components_map() -> dict:
     components_map = {
         'PlanningUnitID': 'planning_unit',
-        'Gauge': 'gauge',
+        'Gauge': 'Gauge',
         'Code': 'EWR_code',
         'FlowThresholdMin': 'min_flow',
         'FlowThresholdMax': 'max_flow',

--- a/py_ewr/data_inputs.py
+++ b/py_ewr/data_inputs.py
@@ -14,14 +14,14 @@ BASE_PATH = Path(__file__).resolve().parent
 
 @cached(cache=TTLCache(maxsize=1024, ttl=1800))
 def get_ewr_calc_config(file_path:str = None) -> dict:
-    '''Loads the EWR calculation configuration file from repository or local file
+    '''Loads the ewr calculation configuration file from repository or local file
     system
     
     Args:
-        file_path (str): Location of the EWR calculation configuration file
+        file_path (str): Location of the ewr calculation configuration file
 
     Returns:
-        dict: Returns a dictionary of the EWR calculation configuration file
+        dict: Returns a dictionary of the ewr calculation configuration file
     '''
     
     if file_path:
@@ -37,7 +37,7 @@ def get_ewr_calc_config(file_path:str = None) -> dict:
 
 def modify_EWR_table(EWR_table:pd.DataFrame) -> pd.DataFrame:
   
-    ''' Does all miscellaneous changes to the EWR table to get in the right format for all the handling functions. i.e. datatype changing, splitting day/month data, handling %
+    ''' Does all miscellaneous changes to the ewr table to get in the right format for all the handling functions. i.e. datatype changing, splitting day/month data, handling %
     '''
 
     int_components = ['FlowThresholdMin', 'FlowThresholdMax', 'VolumeThreshold', 'Duration', 'WithinEventGapTolerance', 'EventsPerYear', 'MinSpell', 'AccumulationPeriod', 'MaxSpell', 'TriggerDay', 'TriggerMonth', 'AnnualBarrageFlow', 'ThreeYearsBarrageFlow', 'HighReleaseWindowStart', 'HighReleaseWindowEnd', 'LowReleaseWindowStart', 'LowReleaseWindowEnd', 'PeakLevelWindowStart', 'PeakLevelWindowEnd', 'LowLevelWindowStart', 'LowLevelWindowEnd', 'NonFlowSpell', 'EggsDaysSpell', 'LarvaeDaysSpell', 'StartDay', 'EndDay', 'StartMonth', 'EndMonth']
@@ -79,7 +79,7 @@ def get_EWR_table(file_path:str = None) -> dict:
     does some cleaning, including swapping out '?' in the frequency column with 0
     
     Args:
-        file_path (str): Location of the EWR dataset
+        file_path (str): Location of the ewr dataset
     Returns:
         tuple(pd.DataFrame, pd.DataFrame): EWRs that meet the minimum requirements; EWRs that dont meet the minimum requirements
     '''
@@ -298,8 +298,8 @@ def get_multi_gauges(dataType: str) -> dict:
 
 def get_EWR_components(category):
     '''
-    Ingests EWR category, returns the components required to analyse this type of EWR. 
-    Each code represents a unique component in the EWR dataset.
+    Ingests ewr category, returns the components required to analyse this type of ewr. 
+    Each code represents a unique component in the ewr dataset.
 
     Args:
         category (str): options =   'flow', 'low flow', 'cease to flow', 'cumulative', 'level', 'weirpool-raising', 'weirpool-falling', 'nest-level', 'nest-percent',
@@ -307,7 +307,7 @@ def get_EWR_components(category):
                                     'simul-gauge-flow', 'simul-gauge-low flow', 'simul-gauge-cease to flow', 'complex'
 
     Returns:
-        list: Components needing to be pulled from the EWR dataset
+        list: Components needing to be pulled from the ewr dataset
     '''
 
     if category == 'flow':
@@ -363,18 +363,18 @@ def get_bad_QA_codes() -> list:
     '''
     return [151, 152, 153, 155, 180, 201, 202, 204, 205, 207, 223, 255]
 
-def weirpool_type(EWR: str) -> str:
-    '''Returns the type of Weirpool EWR. Currently only WP2 EWRs are classified as weirpool raisings
+def weirpool_type(ewr: str) -> str:
+    '''Returns the type of Weirpool ewr. Currently only WP2 EWRs are classified as weirpool raisings
     
     Args:
-        EWR (str): WP2 is considered raising, the remaining WP EWRs are considered falling
+        ewr (str): WP2 is considered raising, the remaining WP EWRs are considered falling
 
     Returns:
         str: either 'raising' or 'falling'
     
     '''
 
-    return 'raising' if EWR == 'WP2' else 'falling'
+    return 'raising' if ewr == 'WP2' else 'falling'
 
 @cached(cache=TTLCache(maxsize=1024, ttl=1800))
 def get_planning_unit_info() -> pd.DataFrame:
@@ -392,24 +392,24 @@ def get_planning_unit_info() -> pd.DataFrame:
 
 
 
-# Function to pull out the EWR parameter information
-def ewr_parameter_grabber(EWR_TABLE: pd.DataFrame, GAUGE: str, PU: str, EWR: str, PARAMETER: str) -> str:
+# Function to pull out the ewr parameter information
+def ewr_parameter_grabber(EWR_TABLE: pd.DataFrame, gauge: str, pu: str, ewr: str, PARAMETER: str) -> str:
     '''
-    Input an EWR table to pull data from, a gauge, planning unit, and EWR for the unique value, and a requested parameter
+    Input an ewr table to pull data from, a gauge, planning unit, and ewr for the unique value, and a requested parameter
 
     Args:
         EWR_TABLE (pd.DataFrame): dataset of EWRs
-        GAUGE (str): Gauge string
-        PU (str): Planning unit name
-        EWR (str): EWR string
-        PARAMETER (str): which parameter of the EWR to access
+        gauge (str): Gauge string
+        pu (str): Planning unit name
+        ewr (str): ewr string
+        PARAMETER (str): which parameter of the ewr to access
     Results:
-        str: requested EWR component
+        str: requested ewr component
     
     '''
-    component = (EWR_TABLE[((EWR_TABLE['Gauge'] == GAUGE) & 
-                           (EWR_TABLE['Code'] == EWR) &
-                           (EWR_TABLE['PlanningUnitName'] == PU)
+    component = (EWR_TABLE[((EWR_TABLE['Gauge'] == gauge) & 
+                           (EWR_TABLE['Code'] == ewr) &
+                           (EWR_TABLE['PlanningUnitName'] == pu)
                           )][PARAMETER]).to_list()[0]
     return component if component else 0
 

--- a/py_ewr/evaluate_EWRs.py
+++ b/py_ewr/evaluate_EWRs.py
@@ -2117,7 +2117,7 @@ def what_cllmm_type(EWR_info: dict) -> str:
     Returns:
         str: 'a' if the EWR code contains '_a', 'b' otherwise
     """
-    ewr_code = EWR_info['EWR_code']
+    ewr_code = EWR_info['Code']
 
     return ewr_code.split('_')[0][-1]
 
@@ -2141,7 +2141,7 @@ def barrage_flow_check(EWR_info: dict, flows: pd.Series, event: list, all_events
     if cllmm_type == 'a':
         last_year_flows = filter_last_year_flows(flows, flow_date)
         
-        if 'S' in EWR_info['EWR_code']:
+        if 'S' in EWR_info['Code']:
             if last_year_flows.sum() >= EWR_info['annual_barrage_flow']:
                 threshold_flow = (get_index_date(flow_date), last_year_flows.sum())
                 event.append(threshold_flow)
@@ -4212,10 +4212,10 @@ def event_stats(df:pd.DataFrame, PU_df:pd.DataFrame, gauge:str, EWR:str, EWR_inf
     ## reset the no_events to keep functionality but switched off
     no_events = construct_event_dict(water_years)
 
-    if EWR_info['EWR_code'] in ['rANA']:
+    if EWR_info['Code'] in ['rANA']:
         years_with_events = get_event_years_connecting_events(events, unique_water_years)
     
-    if EWR_info['EWR_code'] in ['CF1_c','CF1_C']:
+    if EWR_info['Code'] in ['CF1_c','CF1_C']:
         years_with_events = get_event_years_max_rolling_days(events, unique_water_years)
 
     if EWR_info['flow_level_volume'] == 'V':
@@ -4226,7 +4226,7 @@ def event_stats(df:pd.DataFrame, PU_df:pd.DataFrame, gauge:str, EWR:str, EWR_inf
     # Number of event achievements:
     num_event_achievements = get_achievements(EWR_info, events, unique_water_years, durations)
 
-    if EWR_info['EWR_code'] in ['rANA']:
+    if EWR_info['Code'] in ['rANA']:
         num_event_achievements = get_achievements_connecting_events(events, unique_water_years)
 
     NEA = pd.Series(name = str(EWR + '_numAchieved'), data= num_event_achievements, index = unique_water_years)

--- a/py_ewr/evaluate_EWRs.py
+++ b/py_ewr/evaluate_EWRs.py
@@ -2117,9 +2117,9 @@ def what_cllmm_type(EWR_info: dict) -> str:
     Returns:
         str: 'a' if the EWR code contains '_a', 'b' otherwise
     """
-    ewr_code = EWR_info['Code']
+    ewr = EWR_info['Code']
 
-    return ewr_code.split('_')[0][-1]
+    return ewr.split('_')[0][-1]
 
 
 def barrage_flow_check(EWR_info: dict, flows: pd.Series, event: list, all_events: dict, flow_date: date) -> tuple:

--- a/py_ewr/evaluate_EWRs.py
+++ b/py_ewr/evaluate_EWRs.py
@@ -20,59 +20,59 @@ warnings.simplefilter(action='ignore', category=pd.errors.PerformanceWarning)
 
 #----------------------------------- Getting EWRs from the database ------------------------------#
 
-def component_pull(EWR_table: pd.DataFrame, gauge: str, PU: str, EWR: str, component: str, pu_ID: bool = True) -> str:
-    '''Pass EWR details (planning unit, gauge, EWR, and EWR component) and the EWR table, 
+def component_pull(EWR_table: pd.DataFrame, gauge: str, pu: str, ewr: str, component: str, pu_ID: bool = True) -> str:
+    '''Pass ewr details (planning unit, gauge, ewr, and ewr component) and the ewr table, 
     this function will then pull the component from the table.
 
     Args:
         EWR_table (pd.DataFrame): Dataframe of EWRs
         gauge (str): Gauge number
-        PU (str): Planning Unit ID
-        EWR (str): EWR code
-        component (str): EWR parameter (data from which column in the EWR table)
+        pu (str): Planning Unit ID
+        ewr (str): ewr code
+        component (str): ewr parameter (data from which column in the ewr table)
 
     Results:
-        str: value of requested parameter from the EWR table
+        str: value of requested parameter from the ewr table
 
     '''
     if pu_ID:
-        pu_idx = EWR_table['PlanningUnitID'] == PU
+        pu_idx = EWR_table['PlanningUnitID'] == pu
     else:
-        pu_idx = EWR_table['PlanningUnitName'] == PU
+        pu_idx = EWR_table['PlanningUnitName'] == pu
         
     gauge_idx = EWR_table['Gauge'] == gauge
-    ewr_idx = EWR_table['Code'] == EWR
+    ewr_idx = EWR_table['Code'] == ewr
 
     value = EWR_table[(gauge_idx & ewr_idx & pu_idx)].loc[:, component].values[0]
     return value
 
-def get_EWRs(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, components: list) -> dict:
-    '''Pulls the relevant EWR componenets for each EWR
+def get_EWRs(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, components: list) -> dict:
+    '''Pulls the relevant ewr componenets for each ewr
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge ID
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset
-        components (list): List of parameters needing to be pulled from the EWR dataset
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset
+        components (list): List of parameters needing to be pulled from the ewr dataset
    
     Results:
-        dict: The EWR components and their values
+        dict: The ewr components and their values
         
     '''
 
     components_map = data_inputs.get_components_map()
 
     col_idx = ['PlanningUnitID'] + ['Gauge'] + ['Code'] + components
-    row_idx = (EWR_table['PlanningUnitID'] == PU) & (EWR_table['Gauge'] == gauge) & (EWR_table['Code'] == EWR)
+    row_idx = (EWR_table['PlanningUnitID'] == pu) & (EWR_table['Gauge'] == gauge) & (EWR_table['Code'] == ewr)
 
-    ewr_dict = EWR_table.loc[row_idx, col_idx].to_dict(orient='records')[0] # convert the required part of the EWR table to a dictionary
+    ewr_dict = EWR_table.loc[row_idx, col_idx].to_dict(orient='records')[0] # convert the required part of the ewr table to a dictionary
     ewr_dict = {components_map[key]: ewr_dict[key] for key in ewr_dict.keys()} # Rename dictionary to names required for the function calls
 
     return ewr_dict
 
 def is_multigauge(parameter_sheet: pd.DataFrame, gauge:float, ewr:str, pu:str) -> bool:
-    """check in the parameter sheet if currently iterated EWR is a multigauge
+    """check in the parameter sheet if currently iterated ewr is a multigauge
 
     Args:
         parameter_sheet (pd.DataFrame): parameter sheet used in the calculation
@@ -88,10 +88,10 @@ def is_multigauge(parameter_sheet: pd.DataFrame, gauge:float, ewr:str, pu:str) -
         mg = item['Multigauge'].values[0]
         return bool(mg) 
     except IndexError:
-        raise IndexError(f"EWR: gauge={gauge}, code={ewr}, pu={pu} is not in the parameter sheet")
+        raise IndexError(f"ewr: gauge={gauge}, code={ewr}, pu={pu} is not in the parameter sheet")
 
 def is_weirpool_gauge(parameter_sheet: pd.DataFrame, gauge:float, ewr:str, pu:str) -> bool:
-    """check in the parameter sheet if currently iterated EWR is a weirpool gauge
+    """check in the parameter sheet if currently iterated ewr is a weirpool gauge
 
     Args:
         parameter_sheet (pd.DataFrame): parameter sheet used in the calculation
@@ -107,7 +107,7 @@ def is_weirpool_gauge(parameter_sheet: pd.DataFrame, gauge:float, ewr:str, pu:st
         wp = item['WeirpoolGauge'].values[0]
         return bool(wp)
     except IndexError:
-        raise IndexError(f"EWR: gauge={gauge}, code={ewr}, pu={pu} is not in the parameter sheet")
+        raise IndexError(f"ewr: gauge={gauge}, code={ewr}, pu={pu} is not in the parameter sheet")
 
 def calculate_n_day_moving_average(df: pd.DataFrame, days: int) -> pd.DataFrame:
     '''Calculates the n day moving average for a given gauges
@@ -135,13 +135,13 @@ def calculate_n_day_moving_average(df: pd.DataFrame, days: int) -> pd.DataFrame:
 
     return result_df
 
-#------------------------ Masking timeseries data to dates in EWR requirement --------------------#
+#------------------------ Masking timeseries data to dates in ewr requirement --------------------#
 
 def mask_dates(EWR_info: dict, input_df: pd.DataFrame) -> set:
     '''Distributes flow/level dataframe to functions for masking over dates
     
     Args:
-        EWR_info (dict): The EWR components and their values
+        EWR_info (dict): The ewr components and their values
         input_df (pd.DataFrame): Flow/water level dataframe
     
     Results:
@@ -233,7 +233,7 @@ def wateryear_daily(input_df: pd.DataFrame, ewrs: dict) -> np.array:
     
     Args:
         input_df (pd.DataFrame): Flow/water level dataframe
-        ewrs (dict): The EWR components and their values
+        ewrs (dict): The ewr components and their values
 
     Results:
         np.array: array containing the daily assignment of water year
@@ -288,361 +288,361 @@ def get_index_date(date_index:Any)-> datetime.date:
         return date_index
     #     return date_index #TODO: should this break? i.e. we arent expecting other date formats
 
-#----------------------------------- EWR handling functions --------------------------------------#
+#----------------------------------- ewr handling functions --------------------------------------#
 
-def ctf_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def ctf_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling Cease to flow type EWRs
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information 
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information 
 
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('cease to flow')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
-    # Check flow data against EWR requirements and then perform analysis on the results:
+    # Check flow data against ewr requirements and then perform analysis on the results:
     if ((EWR_info['start_month'] == 7) and (EWR_info['end_month'] == 6)):
         E, D = ctf_calc_anytime(EWR_info, df_F[gauge].values, water_years, df_F.index)
     else:
         E, D = ctf_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def lowflow_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def lowflow_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling low flow type EWRs (Very low flows and baseflows)
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information 
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information 
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('low flow')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
-    # Check flow data against EWR requirements and then perform analysis on the results:
+    # Check flow data against ewr requirements and then perform analysis on the results:
     E, D = lowflow_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def flow_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def flow_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling non low flow based flow EWRs (freshes, bankfulls, overbanks)
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information 
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information 
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('flow')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
-    # Check flow data against EWR requirements and then perform analysis on the results:
+    # Check flow data against ewr requirements and then perform analysis on the results:
     E, D = flow_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def flow_handle_anytime(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def flow_handle_anytime(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling flow based flow EWRs (freshes, bankfulls, overbanks) to allow flows to continue to record
     if it crosses water year boundaries.
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information 
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information 
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('flow')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # # Mask dates
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
-    # Check flow data against EWR requirements and then perform analysis on the results
+    # Check flow data against ewr requirements and then perform analysis on the results
     if ((EWR_info['start_month'] == 7) and (EWR_info['end_month'] == 6)):
         E,  D = flow_calc_anytime(EWR_info, df_F[gauge].values, water_years, df_F.index)
     else:
         E,  D = flow_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def flow_handle_check_ctf(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def flow_handle_check_ctf(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling non low flow based flow EWRs 
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information 
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information 
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('flow-ctf')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
-    # Check flow data against EWR requirements and then perform analysis on the results:
+    # Check flow data against ewr requirements and then perform analysis on the results:
     E, D = flow_calc_check_ctf(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def cumulative_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame):
+def cumulative_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame):
     '''For handling cumulative flow EWRs (some large freshes and overbanks, wetland flows).
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information    
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information    
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('cumulative')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
     E, D = cumulative_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
 
     return PU_df, tuple([E])
 
-def cumulative_handle_qld(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame):
+def cumulative_handle_qld(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame):
     '''For handling cumulative flow EWRs this to meet QLD requirements for bird breeding type 2.
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information    
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information    
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('cumulative')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
     E, D = cumulative_calc_qld(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
 
     return PU_df, tuple([E])
 
-def cumulative_handle_bbr(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame):
+def cumulative_handle_bbr(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame):
     '''For handling cumulative flow EWRs (for bird breeding ewr QLD).
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
         df_L (pd.DataFrame): Daily water level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information    
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information    
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('cumulative_bbr') 
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
      # If there is no level data loaded in, let user know and skip the analysis
     try:
         levels = df_L[EWR_info['weirpool_gauge']].values
     except KeyError:
-        print(f'''Cannot evaluate this ewr for {gauge} {EWR}, due to missing data. Specifically this EWR 
+        print(f'''Cannot evaluate this ewr for {gauge} {ewr}, due to missing data. Specifically this ewr 
         also needs data for level gauge {EWR_info.get('weirpool_gauge', 'gauge data')}''')
         return PU_df, None
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
     E, D = cumulative_calc_bbr(EWR_info, df_F[gauge].values, levels, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
 
     return PU_df, tuple([E])
 
-def water_stability_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, 
+def water_stability_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, 
                            PU_df: pd.DataFrame):
     '''For handling Fish Recruitment with water stability requirement (QLD).
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
         df_L (pd.DataFrame): Daily water level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information    
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information    
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('water_stability') 
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
      # If there is no level data loaded in, let user know and skip the analysis
     try:
         levels = df_L[EWR_info['weirpool_gauge']].values
     except KeyError:
-        print(f'''Cannot evaluate this ewr for {gauge} {EWR}, due to missing data. Specifically this EWR 
+        print(f'''Cannot evaluate this ewr for {gauge} {ewr}, due to missing data. Specifically this ewr 
         also needs data for level gauge {EWR_info.get('weirpool_gauge', 'gauge data')}''')
         return PU_df, None
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
     E, D = water_stability_calc(EWR_info, df_F[gauge].values, levels, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
 
     return PU_df, tuple([E])
 
-def water_stability_level_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame):
+def water_stability_level_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame):
     '''For handling Fish Recruitment with water stability requirement (QLD).
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
         df_L (pd.DataFrame): Daily water level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information    
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information    
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('water_stability_level') 
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_L)
      # If there is no level data loaded in, let user know and skip the analysis
     try:
         levels = df_L[EWR_info['weirpool_gauge']].values
     except KeyError:
-        print(f'''Cannot evaluate this ewr for {gauge} {EWR}, due to missing data. Specifically this EWR 
+        print(f'''Cannot evaluate this ewr for {gauge} {ewr}, due to missing data. Specifically this ewr 
         also needs data for level gauge {EWR_info.get('weirpool_gauge', 'gauge data')}''')
         return PU_df, None
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_L, EWR_info)
     E, D = water_stability_level_calc(EWR_info, levels, water_years, df_L.index, masked_dates)
-    PU_df = event_stats(df_L, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_L, PU_df, gauge, ewr, EWR_info, E, D, water_years)
 
     return PU_df, tuple([E])
 
-def level_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def level_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling level type EWRs (low, mid, high and very high level lake fills).
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_L (pd.DataFrame): Daily water level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information        
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information        
     
     '''
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('level')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_L) 
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_L, EWR_info)  
     E, D = lake_calc(EWR_info, df_L[gauge].values, water_years, df_L.index, masked_dates)
-    PU_df = event_stats(df_L, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_L, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def weirpool_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def weirpool_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling weirpool type EWRs.
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
         df_L (pd.DataFrame): Daily water level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information
     
     '''
 
-    # Get information about EWR (changes depending on the weirpool type):
-    weirpool_type = data_inputs.weirpool_type(EWR)
+    # Get information about ewr (changes depending on the weirpool type):
+    weirpool_type = data_inputs.weirpool_type(ewr)
     if weirpool_type == 'raising':
         pull = data_inputs.get_EWR_components('weirpool-raising')
     elif weirpool_type == 'falling':
         pull = data_inputs.get_EWR_components('weirpool-falling')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates for both the flow and level dataframes:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years:
@@ -652,37 +652,37 @@ def weirpool_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F
         levels = df_L[EWR_info['weirpool_gauge']].values
         
     except KeyError:
-        print(f'''Cannot evaluate this ewr for {gauge} {EWR}, due to missing data. Specifically this EWR 
+        print(f'''Cannot evaluate this ewr for {gauge} {ewr}, due to missing data. Specifically this ewr 
         also needs data for level gauge {EWR_info.get('weirpool_gauge', 'no wp gauge')}''')
         return PU_df, None
-    # Check flow and level data against EWR requirements and then perform analysis on the results: 
+    # Check flow and level data against ewr requirements and then perform analysis on the results: 
     E, D = weirpool_calc(EWR_info, df_F[gauge].values, levels, water_years, weirpool_type, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def nest_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def nest_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling nest style EWRs.
 
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
         df_L (pd.DataFrame): Daily water level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information    
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information    
     
     '''
-    # Get information about EWR (changes depending on if theres a weirpool level gauge in the EWR)
-    requires_weirpool_gauge =  is_weirpool_gauge(EWR_table, gauge, EWR, PU)
+    # Get information about ewr (changes depending on if theres a weirpool level gauge in the ewr)
+    requires_weirpool_gauge =  is_weirpool_gauge(EWR_table, gauge, ewr, pu)
     if requires_weirpool_gauge:
         pull = data_inputs.get_EWR_components('nest-level')
     else:
         pull = data_inputs.get_EWR_components('nest-percent')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years:
     water_years = wateryear_daily(df_F, EWR_info)
@@ -702,37 +702,37 @@ def nest_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd
             # If its a nest with a weirpool requirement, do not analyses without the level data:
             levels = df_L[EWR_info['weirpool_gauge']].values
         except KeyError:
-            print(f'''Cannot evaluate this ewr for {gauge} {EWR}, due to missing data. Specifically this EWR 
+            print(f'''Cannot evaluate this ewr for {gauge} {ewr}, due to missing data. Specifically this ewr 
             also needs data for level gauge {EWR_info.get('weirpool_gauge', 'no wp gauge')}''')
             return PU_df, None
         # handle any error in missing values in parameter sheet
         try:
             E, D = nest_calc_weirpool(EWR_info, df_F[gauge].values, levels, water_years, df_F.index, masked_dates)
         except KeyError:
-            log.info(f'''Cannot evaluate this ewr for {gauge} {EWR}, due to missing parameter data. Specifically this EWR 
+            log.info(f'''Cannot evaluate this ewr for {gauge} {ewr}, due to missing parameter data. Specifically this ewr 
             also needs data for level threshold min or level threshold max''')
             return PU_df, None
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def flow_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def flow_handle_multi(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling flow EWRs where flow needs to be combined at two gauges
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information     
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information     
     
     '''
-    # Get information about the EWR:
+    # Get information about the ewr:
     pull = data_inputs.get_EWR_components('multi-gauge-flow')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask the dates:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years:
@@ -743,34 +743,34 @@ def flow_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df
         flows2 = df_F[EWR_info['second_gauge']].values
         flows = flows1 + flows2
     except KeyError:
-        print(f'''This {EWR} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
-        The EWR tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
+        print(f'''This {ewr} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
+        The ewr tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
         flow at the gauge {gauge}. If you are running a model scenario through please disregard this message - most hydrology models have already
         summed flows at these two gauges.''')
         flows = flows1
 
     E, D = flow_calc(EWR_info, flows, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def lowflow_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def lowflow_handle_multi(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling low flow EWRs where flow needs to be combined at two gauges.
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information  
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information  
     
     '''
-    # Get information about the EWR:
+    # Get information about the ewr:
     pull = data_inputs.get_EWR_components('multi-gauge-low flow')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
@@ -781,34 +781,34 @@ def lowflow_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame,
         flows2 = df_F[EWR_info['second_gauge']].values
         flows = flows1 + flows2
     except KeyError:
-        print(f'''This {EWR} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
-        The EWR tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
+        print(f'''This {ewr} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
+        The ewr tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
         flow at the gauge {gauge}. If you are running a model scenario through please disregard this message - most hydrology models have already
         summed flows at these two gauges.''')
         flows = flows1
-    # Check flow data against EWR requirements and then perform analysis on the results: 
+    # Check flow data against ewr requirements and then perform analysis on the results: 
     E, D = lowflow_calc(EWR_info, flows, water_years, df_F.index, masked_dates)  
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
  
-def ctf_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def ctf_handle_multi(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling cease to flow EWRs where flow needs to be combined at two gauges
 
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information  
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information  
     
     '''
-    # Get information about the EWR:
+    # Get information about the ewr:
     pull = data_inputs.get_EWR_components('multi-gauge-cease to flow')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
@@ -819,37 +819,37 @@ def ctf_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_
         flows2 = df_F[EWR_info['second_gauge']].values
         flows = flows1 + flows2
     except KeyError:
-        print(f'''This {EWR} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
-        The EWR tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
+        print(f'''This {ewr} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
+        The ewr tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
         flow at the gauge {gauge}. If you are running a model scenario through please disregard this message - most hydrology models have already
         summed flows at these two gauges.''')
         flows = flows1
-    # Check flow data against EWR requirements and then perform analysis on the results:
+    # Check flow data against ewr requirements and then perform analysis on the results:
     if ((EWR_info['start_month'] == 7) and (EWR_info['end_month'] == 6)):
         E, D = ctf_calc_anytime(EWR_info, df_F[gauge].values, water_years, df_F.index)
     else:
         E, D = ctf_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def cumulative_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def cumulative_handle_multi(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling cumulative volume EWRs where flow needs to be combined at two gauges.
 
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information      
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information      
     
     '''
-    # Get information about the EWR:
+    # Get information about the ewr:
     pull = data_inputs.get_EWR_components('multi-gauge-cumulative')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years
@@ -860,58 +860,58 @@ def cumulative_handle_multi(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFra
         flows2 = df_F[EWR_info['second_gauge']].values
         flows = flows1 + flows2
     except KeyError:
-        print(f'''This {EWR} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
-        The EWR tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
+        print(f'''This {ewr} at the gauge {gauge} sums the flows at two gauges ({gauge} and {EWR_info['second_gauge']}.
+        The ewr tool has not been able to find the flow data for {EWR_info["second_gauge"]} so it will only evaluate EWRs against the
         flow at the gauge {gauge}. If you are running a model scenario through please disregard this message - most hydrology models have already
         summed flows at these two gauges.''')
         flows = flows1
     E, D = cumulative_calc(EWR_info, flows, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)    
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)    
     return PU_df, tuple([E])
 
 
-def flow_handle_sa(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def flow_handle_sa(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     '''For handling SA IC(in channel) and FP (flood plain) type EWRs.
     It checks Flow thresholds, and check for Flow raise and fall.
     
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
         df_L (pd.DataFrame): Daily water level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Results:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information
     
     '''
 
     pull = data_inputs.get_EWR_components('flood-plains')
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates for both the flow and level dataframes:
     masked_dates = mask_dates(EWR_info, df_F)
     # Extract a daily timeseries for water years:
     water_years = wateryear_daily(df_F, EWR_info)
 
     E, D = flow_calc_sa(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
     return PU_df, tuple([E])
 
-def barrage_flow_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def barrage_flow_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     """handle function to calculate barrage flow type EWRs
 
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_F (pd.DataFrame): Daily flow data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Returns:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information
     """
     barrage_flow_gauges = data_inputs.get_barrage_flow_gauges()
     all_required_gauges = barrage_flow_gauges.get(gauge)
@@ -920,7 +920,7 @@ def barrage_flow_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, 
     # check if current gauge is the main barrage gauge
         if all_required_gauges_in_df_F:
             pull = data_inputs.get_EWR_components('barrage-flow')
-            EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+            EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
             # Mask dates for both the flow and level dataframes:
             # Extract a daily timeseries for water years:
             water_years = wateryear_daily(df_F, EWR_info)
@@ -928,25 +928,25 @@ def barrage_flow_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, 
             df = df_F.copy(deep=True)
             df['combined_flow'] = df[all_required_gauges].sum(axis=1)
             E, D = barrage_flow_calc(EWR_info, df['combined_flow'], water_years, df_F.index)
-            PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+            PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
             return PU_df, tuple([E])
     else:
         print(f'Missing data for barrage gauges {" ".join(all_required_gauges)}')
         return PU_df, None
 
-def barrage_level_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def barrage_level_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     """handle function to calculate barrage level type EWRs
 
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset 
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset 
         df_L (pd.DataFrame): Daily level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Returns:
-        tuple[pd.DataFrame, tuple[dict]]: EWR results for the current planning unit iteration (updated); dictionary of EWR event information
+        tuple[pd.DataFrame, tuple[dict]]: ewr results for the current planning unit iteration (updated); dictionary of ewr event information
     """
     barrage_level_gauges = data_inputs.get_barrage_level_gauges()
     all_required_gauges = barrage_level_gauges.get(gauge)
@@ -958,7 +958,7 @@ def barrage_level_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame,
         # directly subset and use all_required_gauges_in_df_L as the new list. 
     if all_required_gauges_in_df_L:
         pull = data_inputs.get_EWR_components('barrage-level')
-        EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+        EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
         masked_dates = mask_dates(EWR_info, df_L)
         # Extract a daily timeseries for water years:
         water_years = wateryear_daily(df_L, EWR_info)
@@ -973,48 +973,48 @@ def barrage_level_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame,
         if cllmm_type == 'd':
             E, D = coorong_level_calc(EWR_info, df_5_day_averages['mean'], water_years, df_L.index, masked_dates)
         
-        PU_df = event_stats(df_L, PU_df, gauge, EWR, EWR_info, E, D, water_years)    
+        PU_df = event_stats(df_L, PU_df, gauge, ewr, EWR_info, E, D, water_years)    
         return PU_df, tuple([E])
 
     else:
         print(f'skipping calculation because gauge {" ".join(all_required_gauges)} is not the main barrage level gauge ') #TODO: improve error message
         return PU_df, None
 
-def rise_and_fall_handle(PU: str, gauge: str, EWR: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
+def rise_and_fall_handle(pu: str, gauge: str, ewr: str, EWR_table: pd.DataFrame, df_F: pd.DataFrame, df_L: pd.DataFrame, PU_df: pd.DataFrame) -> tuple:
     """For handling rise and fall EWRs of type FLOW and LEVEL.
 
     Args:
-        PU (str): Planning unit ID
+        pu (str): Planning unit ID
         gauge (str): Gauge number
-        EWR (str): EWR code
-        EWR_table (pd.DataFrame): EWR dataset
+        ewr (str): ewr code
+        EWR_table (pd.DataFrame): ewr dataset
         df_F (pd.DataFrame): Daily flow data
         df_L (pd.DataFrame): Daily level data
-        PU_df (pd.DataFrame): EWR results for the current planning unit iteration
+        PU_df (pd.DataFrame): ewr results for the current planning unit iteration
 
     Returns:
-        tuple[pd.DataFrame, tuple[dict]]: EWRS results for the current planning unit iteration (updated); dictionary of EWR event information
+        tuple[pd.DataFrame, tuple[dict]]: EWRS results for the current planning unit iteration (updated); dictionary of ewr event information
     """
    
-    # Get information about EWR:
+    # Get information about ewr:
     pull = data_inputs.get_EWR_components('rise_fall') 
-    EWR_info = get_EWRs(PU, gauge, EWR, EWR_table, pull)
+    EWR_info = get_EWRs(pu, gauge, ewr, EWR_table, pull)
     # Mask dates:
     masked_dates = mask_dates(EWR_info, df_F)
      # If there is no level data loaded in, let user know and skip the analysis
     # Extract a daily timeseries for water years
     water_years = wateryear_daily(df_F, EWR_info)
 
-    if 'RRF' in EWR:
+    if 'RRF' in ewr:
         E, D = rate_rise_flow_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    if 'RFF' in EWR:
+    if 'RFF' in ewr:
         E, D = rate_fall_flow_calc(EWR_info, df_F[gauge].values, water_years, df_F.index, masked_dates)
-    if 'RRL' in EWR:
+    if 'RRL' in ewr:
         E, D = rate_rise_level_calc(EWR_info, df_L[gauge].values, water_years, df_F.index, masked_dates)
-    if 'RFL' in EWR:
+    if 'RFL' in ewr:
         E, D = rate_fall_level_calc(EWR_info, df_L[gauge].values, water_years, df_F.index, masked_dates)
 
-    PU_df = event_stats(df_F, PU_df, gauge, EWR, EWR_info, E, D, water_years)
+    PU_df = event_stats(df_F, PU_df, gauge, ewr, EWR_info, E, D, water_years)
 
     return PU_df, tuple([E])
 
@@ -1128,7 +1128,7 @@ def years_lengths(event_info: tuple)-> list:
 
 def which_year_lake_event(event_info: tuple, min_duration: int)-> int:
     """given a event info and a event min duration it returns the
-    year the event has to be recorded according to the lake level EWR rule
+    year the event has to be recorded according to the lake level ewr rule
 
     If not at year boundary the event will be recorded.
 
@@ -1165,13 +1165,13 @@ def achieved_min_volume(event: List[tuple], EWR_info: Dict)-> bool:
 
 def flow_check(EWR_info: dict, iteration: int, flow: float, event: list, all_events: dict, gap_track: int, 
                water_years: np.array, total_event: int, flow_date: date) -> tuple:
-    '''Checks daily flow against EWR threshold. Builds on event lists and no event counters.
+    '''Checks daily flow against ewr threshold. Builds on event lists and no event counters.
     At the end of the event, if it was long enough, the event is saved against the relevant
     water year in the event dictionary. All event gaps are saved against the relevant water 
     year in the no event dictionary
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         event (list): current event state
@@ -1270,7 +1270,7 @@ def get_threshold_events(EWR_info:dict, flows:list)->list:
     return events
 
 def flow_check_ctf(EWR_info: dict, iteration: int, flows: List,  all_events: dict, water_years: np.array, flow_date: date, ctf_state: dict) -> tuple:
-    '''Checks daily flow against EWR threshold and records dry spells
+    '''Checks daily flow against ewr threshold and records dry spells
     in the ctf_state dictionary in the events key.
     When there are 2 events in the events key it evaluates if there is at least 1 phase 2 event 
     (i.e. event that allow Fish Dispersal) in between the dry spells. If there is no phase 2 event i.e. 
@@ -1278,7 +1278,7 @@ def flow_check_ctf(EWR_info: dict, iteration: int, flows: List,  all_events: dic
     It records in the all_events dictionary from the beginning of the first dry spell to the end of the second dry spell
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         event (list): current event state
@@ -1324,15 +1324,15 @@ def flow_check_ctf(EWR_info: dict, iteration: int, flows: List,  all_events: dic
 def level_check(EWR_info: dict, iteration: int, level:float, level_change:float, 
                event: list, all_events: dict, gap_track: int, 
                water_years: np.array, total_event: int, level_date: date)-> tuple:
-    """Checks daily level against EWR threshold. Builds on event lists and no event counters.
+    """Checks daily level against ewr threshold. Builds on event lists and no event counters.
     At the end of the event, if it was long enough, the event is saved against the relevant
     water year in the event dictionary. All event gaps are saved against the relevant water 
     year in the no event dictionary
-    NOTE: this EWR is a slight variation of the level_check_ltwp as it records the event in a different year depending on
+    NOTE: this ewr is a slight variation of the level_check_ltwp as it records the event in a different year depending on
      the rules in the function which_year_lake_event
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         level (float): current level
         level_change (float): level change in meters from previous day to current day
@@ -1375,13 +1375,13 @@ def nest_flow_check(EWR_info: dict, iteration: int, flow: float, event: list, al
                      gap_track: int, water_years: list, total_event: int, 
                     flow_date: date, flow_percent_change: float, iteration_no_event: int)-> tuple:
 
-    """Checks daily flows against EWR threshold. Builds on event lists and no_event counters.
+    """Checks daily flows against ewr threshold. Builds on event lists and no_event counters.
     At the end of the event, if it was long enough, the event is saved against the relevant
     water year in the event dictionary. All event gaps are saved against the relevant water 
     year in the no event dictionary.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         event (list): current event state
@@ -1418,12 +1418,12 @@ def nest_flow_check(EWR_info: dict, iteration: int, flow: float, event: list, al
 
 
 def lowflow_check(EWR_info: dict, iteration: int, flow: float, event: list, all_events: dict,  water_years: np.array, flow_date: date) -> tuple:
-    '''Checks daily flow against the EWR threshold. Saves all events to the relevant water year
+    '''Checks daily flow against the ewr threshold. Saves all events to the relevant water year
     in the event tracking dictionary. Saves all event gaps to the relevant water year in the 
     no event dictionary.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         event (list): current event state
@@ -1448,12 +1448,12 @@ def lowflow_check(EWR_info: dict, iteration: int, flow: float, event: list, all_
     return event, all_events
 
 def ctf_check(EWR_info: dict, iteration: int, flow: float, event: list, all_events: dict, water_years: np.array, flow_date: date) -> tuple:
-    '''Checks daily flow against the cease to flow EWR threshold. Saves all events to the relevant
+    '''Checks daily flow against the cease to flow ewr threshold. Saves all events to the relevant
     water year in the event tracking dictionary. Saves all no events to the relevant water year
     in the no event dictionary.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         event (list): current event state
@@ -1484,7 +1484,7 @@ def check_roller_reset_points(roller:int, flow_date:date, EWR_info:Dict):
     Args:
         roller (int): how many days to look back on the volume checker window
         flow_date (date): date of the current flow
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
 
     Returns:
         (int): roller value either the same or a reset value
@@ -1499,7 +1499,7 @@ def volume_check(EWR_info:Dict, iteration:int, flow:int, event:List, all_events:
     It looks back in a window of the size of the Accumulation period in(Days)
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (int): current flow
         event (List[float]): current event state
@@ -1509,7 +1509,7 @@ def volume_check(EWR_info:Dict, iteration:int, flow:int, event:List, all_events:
         total_event (int): current total event state
         flow_date (date): current flow date
         roller (int): current roller state
-        max_roller (int): current EWR max roller window
+        max_roller (int): current ewr max roller window
         flows (List): current list of all flows being iterated
 
     Returns:
@@ -1546,7 +1546,7 @@ def volume_check_qld(EWR_info:Dict, iteration:int, event:List, all_events:Dict,
     This is the QLD version of the volume check
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         event (List): current event state
         all_events (Dict): current all events state
@@ -1554,7 +1554,7 @@ def volume_check_qld(EWR_info:Dict, iteration:int, event:List, all_events:Dict,
         total_event (int): current total event state
         flow_date (date):  current flow date
         roller (int):  current roller state
-        max_roller (int): current EWR max roller window
+        max_roller (int): current ewr max roller window
         flows (List): current list of all flows being iterated
 
     Returns:
@@ -1585,7 +1585,7 @@ def volume_level_check_bbr(EWR_info:Dict, iteration:int, flow:float, event:List,
     It looks back in a window of the size of the Accumulation period in(Days)
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (int): current flow
         event (List[float]): current event state
@@ -1595,7 +1595,7 @@ def volume_level_check_bbr(EWR_info:Dict, iteration:int, flow:float, event:List,
         total_event (int): current total event state
         flow_date (date): current flow date
         roller (int): current roller state
-        max_roller (int): current EWR max roller window
+        max_roller (int): current ewr max roller window
         flows (List): current list of all flows being iterated
         levels (List): current list of all levels being iterated
 
@@ -1679,7 +1679,7 @@ def water_stability_check(EWR_info:Dict, iteration:int, flows:List, all_events:D
     if there is an opportunity record the event otherwise go to next day
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (int): current flow
         event (List[float]): current event state
@@ -1718,7 +1718,7 @@ def water_stability_level_check(EWR_info:Dict, iteration:int, all_events:Dict, w
     if there is an opportunity record the event otherwise go to next day
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         event (List[float]): current event state
         all_events (Dict): current all events state
@@ -1752,7 +1752,7 @@ def weirpool_check(EWR_info: dict, iteration: int, flow: float, level: float, ev
     """Check weirpool flow and level if meet condition and update state of the events
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         level (float): current level
@@ -1793,7 +1793,7 @@ def nest_weirpool_check(EWR_info: dict, iteration: int, flow: float, level: floa
     """Check weirpool flow and level if meet condition and update state of the events
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         level (float): current level
@@ -1841,7 +1841,7 @@ def flow_check_rise_fall(EWR_info: dict, iteration: int, flow: float, event: lis
         has fallen below the target minimum discharge metric
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         iteration (int): current iteration
         flow (float): current flow
         event (list): current event state
@@ -2021,7 +2021,7 @@ def filter_timing_window_non_std(flows: pd.Series, flow_date: date, start_month:
 
     Args:
         flows (pd.Series): series of flows
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flow_date (date): current flow date
 
     Returns:
@@ -2041,7 +2041,7 @@ def filter_last_year_flows(flows: pd.Series, flow_date: date) -> pd.Series:
 
     Args:
         flows (pd.Series): series of flows
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flow_date (date): current flow date
 
     Returns:
@@ -2095,7 +2095,7 @@ def filter_last_three_years_flows(flows: pd.Series, flow_date: date) -> pd.Serie
 
     Args:
         flows (pd.Series): series of flows
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flow_date (date): current flow date
 
     Returns:
@@ -2109,13 +2109,13 @@ def filter_last_three_years_flows(flows: pd.Series, flow_date: date) -> pd.Serie
     return flows[last_three_years_mask]
 
 def what_cllmm_type(EWR_info: dict) -> str:
-    """Determine the CLLMM type based on the EWR code.
+    """Determine the CLLMM type based on the ewr code.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
 
     Returns:
-        str: 'a' if the EWR code contains '_a', 'b' otherwise
+        str: 'a' if the ewr code contains '_a', 'b' otherwise
     """
     ewr = EWR_info['Code']
 
@@ -2127,7 +2127,7 @@ def barrage_flow_check(EWR_info: dict, flows: pd.Series, event: list, all_events
     then save the results in the events list and all events dictionary
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flows (pd.Series): series of flows
         event (list): current event state
         all_events (dict): current all events state
@@ -2180,7 +2180,7 @@ def coorong_check(EWR_info: dict, levels: pd.Series, event: list, all_events: di
     """check if current level meet the minimal level requirement for coorong levels.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         levels (pd.Series): series of levels
         event (list): current event state
         all_events (dict): current all events state
@@ -2214,7 +2214,7 @@ def lower_lakes_level_check(EWR_info: dict, levels: pd.Series, event: list, all_
 	If both conditions are met event is counted. 
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         levels (pd.Series): series of levels
         event (list): current event state
         all_events (dict): current all events state
@@ -2283,7 +2283,7 @@ def check_wp_level(weirpool_type: str, level: float, EWR_info: dict)-> bool:
     Args:
         weirpool_type (str): type of weirpool either 'raising' or 'falling'
         level (float): current level
-        EWR_info (dict): EWR parameters
+        EWR_info (dict): ewr parameters
 
     Returns:
         bool: if meet requirements True else False
@@ -2296,7 +2296,7 @@ def check_draw_down(level_change: float, EWR_info: dict) -> bool:
 
     Args:
         level_change (float): change in meters
-        EWR_info (dict): EWR parameters
+        EWR_info (dict): ewr parameters
 
     Returns:
         bool: if pass test returns True and fail return False
@@ -2498,7 +2498,7 @@ def check_period_flow_change(flows: list, EWR_info: dict, iteration: int, mode: 
 
     Args:
         flows (list): Flow time series values
-        EWR_info (dict):EWR parameters
+        EWR_info (dict):ewr parameters
         iteration (int): current iteration
         mode (str): mode to look for flow change. Can be backwards to check before start an event or forwards
         to check after an event ends.
@@ -2534,7 +2534,7 @@ def check_period_flow_change_stepped(flows: list, EWR_info: dict, iteration: int
 
     Args:
         flows (list): Flow time series values
-        EWR_info (dict):EWR parameters
+        EWR_info (dict):ewr parameters
         iteration (int): current iteration
         mode (str): mode to look for flow change. Can be backwards to check before start an event or forwards
         to check after an event ends.
@@ -2573,7 +2573,7 @@ def check_weekly_drawdown(levels: list, EWR_info: dict, iteration: int, event_le
 
     Args:
         levels (float): Level time series values
-        EWR_info (dict): EWR parameters
+        EWR_info (dict): ewr parameters
         iteration (int): current iteration
         event_legth (int): current event length
 
@@ -2611,7 +2611,7 @@ def check_nest_percent_drawdown(flow_percent_change: float, EWR_info: dict, flow
 
     Args:
         flow_percent_change (float): flow percent change
-        EWR_info (Dict): EWR parameters
+        EWR_info (Dict): ewr parameters
         flow (float): current flow
 
     Returns:
@@ -2682,7 +2682,7 @@ def last_year_peak_within_window(last_year_peak: float, levels: pd.Series,  EWR_
 
     Args:
         last_year_peak_date (date): date of the last year peak
-        EWR_info (Dict): EWR parameters
+        EWR_info (Dict): ewr parameters
 
     Returns:
         bool: True if it is within the window otherwise False
@@ -2705,7 +2705,7 @@ def last_year_low_within_window(last_year_low: float, levels: pd.Series,  EWR_in
 
     Args:
         last_year_peak_date (date): date of the last year peak
-        EWR_info (Dict): EWR parameters
+        EWR_info (Dict): ewr parameters
 
     Returns:
         bool: True if it is within the window otherwise False
@@ -2726,10 +2726,10 @@ def last_year_low_within_window(last_year_low: float, levels: pd.Series,  EWR_in
 
 
 def calc_nest_cut_date(EWR_info: dict, iteration: int, dates: list) -> date:
-    """Calculates the last date (date of the month) the nest EWR event is valid
+    """Calculates the last date (date of the month) the nest ewr event is valid
 
     Args:
-        EWR_info (Dict): EWR parameters
+        EWR_info (Dict): ewr parameters
         iteration (int): current iteration
         dates (List): time series dates
 
@@ -2747,7 +2747,7 @@ def lowflow_calc(EWR_info: dict, flows: np.array, water_years: np.array, dates: 
     each water year.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flows (np.array): array of daily flows
         water_years (np.array): array of daily water year values
         dates (np.array): array of dates
@@ -2788,7 +2788,7 @@ def ctf_calc_anytime(EWR_info: dict, flows: np.array, water_years: np.array, dat
     water year.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flows (np.array): array of daily flows
         water_years (np.array): array of daily water year values
         dates (np.array): array of dates
@@ -2825,7 +2825,7 @@ def ctf_calc(EWR_info: dict, flows: np.array, water_years: np.array, dates: np.a
     water year.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flows (np.array): array of daily flows
         water_years (np.array): array of daily water year values
         dates (np.array): array of dates
@@ -2865,7 +2865,7 @@ def flow_calc(EWR_info: dict, flows: np.array, water_years: np.array, dates: np.
     therefore reset at the end of each water year.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flows (np.array): array of daily flows
         water_years (np.array): array of daily water year values
         dates (np.array): array of dates
@@ -2911,7 +2911,7 @@ def flow_calc_check_ctf(EWR_info: dict, flows: np.array, water_years: np.array, 
     n days there was a period of ctf
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flows (np.array): array of daily flows
         water_years (np.array): array of daily water year values
         dates (np.array): array of dates
@@ -2946,7 +2946,7 @@ def flow_calc_anytime(EWR_info: dict, flows: np.array, water_years: np.array, da
     water year boundaries will be saved to the water year where the majority of event days were.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
         flows (np.array): array of daily flows
         water_years (np.array): array of daily water year values
         dates (np.array): array of dates
@@ -2979,18 +2979,18 @@ def flow_calc_anytime(EWR_info: dict, flows: np.array, water_years: np.array, da
 
 
 def lake_calc(EWR_info: dict, levels: np.array, water_years: np.array, dates: np.array, masked_dates: set)-> tuple:
-    """For calculating lake level EWR with or without time constraint (anytime).
+    """For calculating lake level ewr with or without time constraint (anytime).
      At the end of each water year save ongoing event, however not resetting the event list. 
      Let the level_check_ltwp_alt record the event when it finishes and reset the event list.
-     NOTE: this EWR is a slight variation of the lake_calc_ltwp as it records the event in a different year depending on
+     NOTE: this ewr is a slight variation of the lake_calc_ltwp as it records the event in a different year depending on
      the rules in the function which_year_lake_event
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
-        levels (np.array): List with all the levels for the current calculated EWR
-        water_years (np.array): List of the water year of each day of the current calculated EWR
-        dates (np.array): List of the dates of the current calculated EWR
-        masked_dates (set): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
+        levels (np.array): List with all the levels for the current calculated ewr
+        water_years (np.array): List of the water year of each day of the current calculated ewr
+        dates (np.array): List of the dates of the current calculated ewr
+        masked_dates (set): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3032,16 +3032,16 @@ def lake_calc(EWR_info: dict, levels: np.array, water_years: np.array, dates: np
     return all_events, durations
 
 def cumulative_calc(EWR_info: dict, flows: np.array, water_years: np.array, dates: np.array, masked_dates: set)-> tuple:
-    """ Calculate and manage state of the Volume EWR calculations. It delegates to volume_check function
+    """ Calculate and manage state of the Volume ewr calculations. It delegates to volume_check function
     the record of events when they not end at the end of a water year, otherwise it resets the event at year boundary
     adopting the hybrid method
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
-        flows (np.array): List with all the flows for the current calculated EWR
-        water_years (np.array): List of the water year of each day of the current calculated EWR
-        dates (np.array): List of the dates of the current calculated EWR
-        masked_dates (set): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
+        flows (np.array): List with all the flows for the current calculated ewr
+        water_years (np.array): List of the water year of each day of the current calculated ewr
+        dates (np.array): List of the dates of the current calculated ewr
+        masked_dates (set): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3082,16 +3082,16 @@ def cumulative_calc(EWR_info: dict, flows: np.array, water_years: np.array, date
     return all_events, durations
 
 def cumulative_calc_qld(EWR_info: dict, flows: np.array, water_years: np.array, dates: np.array, masked_dates: set)-> tuple:
-    """ Calculate and manage state of the Volume EWR calculations. It delegates to volume_check function
+    """ Calculate and manage state of the Volume ewr calculations. It delegates to volume_check function
     the record of events when they not end at the end of a water year.
     This version does not reset event at year boundary, it accumulates the event until volume drops below threshold.
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
-        flows (np.array): List with all the flows for the current calculated EWR
-        water_years (np.array): List of the water year of each day of the current calculated EWR
-        dates (np.array): List of the dates of the current calculated EWR
-        masked_dates (set): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
+        flows (np.array): List with all the flows for the current calculated ewr
+        water_years (np.array): List of the water year of each day of the current calculated ewr
+        dates (np.array): List of the dates of the current calculated ewr
+        masked_dates (set): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3125,17 +3125,17 @@ def cumulative_calc_qld(EWR_info: dict, flows: np.array, water_years: np.array, 
     return all_events, durations
 
 def cumulative_calc_bbr(EWR_info: dict, flows: np.array, levels: np.array, water_years: np.array, dates: np.array, masked_dates: set)-> tuple:
-    """ Calculate and manage state of the Volume EWR calculations. It delegates to volume_check function
+    """ Calculate and manage state of the Volume ewr calculations. It delegates to volume_check function
     the record of events when they not end at the end of a water year, otherwise it resets the event at year boundary
     adopting the hybrid method
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
-        flows (np.array): List with all the flows for the current calculated EWR
-        levels (np.array): List with all the levels for the current calculated EWR
-        water_years (np.array): List of the water year of each day of the current calculated EWR
-        dates (np.array): List of the dates of the current calculated EWR
-        masked_dates (set): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
+        flows (np.array): List with all the flows for the current calculated ewr
+        levels (np.array): List with all the levels for the current calculated ewr
+        water_years (np.array): List of the water year of each day of the current calculated ewr
+        dates (np.array): List of the dates of the current calculated ewr
+        masked_dates (set): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3172,12 +3172,12 @@ def water_stability_calc(EWR_info: dict, flows: np.array, levels: np.array, wate
     if within season it will look forward if there is an opportunity given the egg and larvae phases are met
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
-        flows (np.array): List with all the flows for the current calculated EWR
-        levels (np.array): List with all the levels for the current calculated EWR
-        water_years (np.array): List of the water year of each day of the current calculated EWR
-        dates (np.array): List of the dates of the current calculated EWR
-        masked_dates (set): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
+        flows (np.array): List with all the flows for the current calculated ewr
+        levels (np.array): List with all the levels for the current calculated ewr
+        water_years (np.array): List of the water year of each day of the current calculated ewr
+        dates (np.array): List of the dates of the current calculated ewr
+        masked_dates (set): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3201,12 +3201,12 @@ def water_stability_level_calc(EWR_info: dict, levels: np.array, water_years: np
     if within season it will look forward if there is an opportunity given the egg and larvae phases are met
 
     Args:
-        EWR_info (dict): dictionary with the parameter info of the EWR being calculated
-        flows (np.array): List with all the flows for the current calculated EWR
-        levels (np.array): List with all the levels for the current calculated EWR
-        water_years (np.array): List of the water year of each day of the current calculated EWR
-        dates (np.array): List of the dates of the current calculated EWR
-        masked_dates (set): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (dict): dictionary with the parameter info of the ewr being calculated
+        flows (np.array): List with all the flows for the current calculated ewr
+        levels (np.array): List with all the levels for the current calculated ewr
+        water_years (np.array): List of the water year of each day of the current calculated ewr
+        dates (np.array): List of the dates of the current calculated ewr
+        masked_dates (set): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3236,12 +3236,12 @@ def nest_calc_weirpool(EWR_info: dict, flows: list, levels: list, water_years: l
 	- To start and end an event the event needs to be in a time window (masked dates).
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        flows (List):  List with all the flows measurements for the current calculated EWR
-        levels (List): List with all the levels measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        flows (List):  List with all the flows measurements for the current calculated ewr
+        levels (List): List with all the levels measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
         weirpool_type (str, optional): type of weirpool either 'raising' or 'falling'. Defaults to "raising".
 
     Returns:
@@ -3288,9 +3288,9 @@ def nest_calc_weirpool(EWR_info: dict, flows: list, levels: list, water_years: l
 
 
 def nest_calc_percent_trigger(EWR_info:Dict, flows:List, water_years:List, dates:List)->tuple:
-    """Do the calculation of the nesting EWR with trigger and % drawdown
+    """Do the calculation of the nesting ewr with trigger and % drawdown
     To start and event it needs to be in a trigger window
-    To sustain the EWR needs to 
+    To sustain the ewr needs to 
     - Be above the flow (min threshold)
     - Does not fall more than the % in a day if between the min and max flow i.e If it is above max flow threshold, percent drawn 
     down rate does not matter 
@@ -3302,11 +3302,11 @@ def nest_calc_percent_trigger(EWR_info:Dict, flows:List, water_years:List, dates
 
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        flows (List):  List with all the flows measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        flows (List):  List with all the flows measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3393,17 +3393,17 @@ def nest_calc_percent_trigger(EWR_info:Dict, flows:List, water_years:List, dates
 
 def weirpool_calc(EWR_info: Dict, flows: List, levels: List, water_years: List, weirpool_type: str, 
                         dates:List, masked_dates:List)-> tuple:
-    """ Iterates each yearly flows to manage calculation of weirpool EWR. It delegates to weirpool_check function
+    """ Iterates each yearly flows to manage calculation of weirpool ewr. It delegates to weirpool_check function
     the record of events which will check the flow and level threshold as all as drawdown of event 
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        flows (List):  List with all the flows measurements for the current calculated EWR
-        levels (List): List with all the levels measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        flows (List):  List with all the flows measurements for the current calculated ewr
+        levels (List): List with all the levels measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
         weirpool_type (str): type of weirpool either 'raising' or 'falling'
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3448,14 +3448,14 @@ def weirpool_calc(EWR_info: Dict, flows: List, levels: List, water_years: List, 
 def flow_calc_sa(EWR_info: Dict, flows: List, water_years: List, 
                         dates:List, masked_dates:List)-> tuple:
     """ Iterates each flows to manage calculation of flow and flows raise and fall. It delegates to flow_check_rise_fall function
-    the record of events which will check the flow changes against the EWR requirements. 
+    the record of events which will check the flow changes against the ewr requirements. 
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        flows (List):  List with all the flows measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        flows (List):  List with all the flows measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3503,11 +3503,11 @@ def rate_rise_flow_calc(EWR_info: Dict, flows: List, water_years: List,
     """ Iterates each flows to manage identify events that meet the rate of flow rise requirements
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        flows (List):  List with all the flows measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        flows (List):  List with all the flows measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3543,11 +3543,11 @@ def rate_fall_flow_calc(EWR_info: Dict, flows: List, water_years: List,
     """ Iterates each flows to manage identify events that meet the rate of fall requirements
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        flows (List):  List with all the flows measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        flows (List):  List with all the flows measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3586,11 +3586,11 @@ def rate_rise_level_calc(EWR_info: Dict, levels: List, water_years: List,
     """ Iterates each flows to manage identify events that meet the rate of fall requirements
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        levels (List):  List with all the levels for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        levels (List):  List with all the levels for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3627,11 +3627,11 @@ def rate_fall_level_calc(EWR_info: Dict, levels: List, water_years: List,
     """ Iterates each flows to manage identify events that meet the rate of fall requirements
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        levels (List):  List with all the levels for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        levels (List):  List with all the levels for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3671,10 +3671,10 @@ def barrage_flow_calc(EWR_info: Dict, flows: pd.Series, water_years: List, dates
     as well as the seasonal flow threshold
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        flows (List):  List with all the flows measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        flows (List):  List with all the flows measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3702,11 +3702,11 @@ def coorong_level_calc(EWR_info: Dict, levels: pd.Series, water_years: List, dat
     """iterate level data for barrage combined levels are with in minimum levels
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        levels (List):  List with all the levels measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        levels (List):  List with all the levels measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events, durations
@@ -3740,11 +3740,11 @@ def lower_lakes_level_calc(EWR_info: Dict, levels: pd.Series, water_years: List,
     if barrage level is at the required minimum as well as the seasonal peak levels threshold
 
     Args:
-        EWR_info (Dict): dictionary with the parameter info of the EWR being calculated
-        levels (List):  List with all the levels measurements for the current calculated EWR
-        water_years (List): List of the water year of each day of the current calculated EWR
-        dates (List): List of the dates of the current calculated EWR
-        masked_dates (List): List of the dates that the EWR needs to be calculated i.e. the time window.
+        EWR_info (Dict): dictionary with the parameter info of the ewr being calculated
+        levels (List):  List with all the levels measurements for the current calculated ewr
+        water_years (List): List of the water year of each day of the current calculated ewr
+        dates (List): List of the dates of the current calculated ewr
+        masked_dates (List): List of the dates that the ewr needs to be calculated i.e. the time window.
 
     Returns:
         tuple: final output with the calculation of volume all_events,  durations
@@ -3768,15 +3768,15 @@ def lower_lakes_level_calc(EWR_info: Dict, levels: pd.Series, water_years: List,
     durations.append(EWR_info['duration'])
     return  all_events, durations
 
-#------------------------------------ Stats on EWR events ----------------------------------------#
+#------------------------------------ Stats on ewr events ----------------------------------------#
 
 def filter_min_events(EWR_info:Dict, events:Dict)-> Dict:
     """Given an events dictionary, filter out all events that are 
     below min_event as they should not contribute to total duration.
 
     Args:
-        EWR_info (Dict): EWR parameters
-        events (Dict): EWR calculation events dictionary
+        EWR_info (Dict): ewr parameters
+        events (Dict): ewr calculation events dictionary
 
     Returns:
         Dict: events dictionary with only events that is above minimum
@@ -3791,7 +3791,7 @@ def get_event_years(EWR_info:Dict, events:Dict, unique_water_years:set, duration
     '''Returns a list of years with events (represented by a 1), and years without events (0)
     
     Args:
-        EWR_info (Dict): EWR parameters
+        EWR_info (Dict): ewr parameters
         events (Dict): Dictionary with water years as keys, and a list of event lists for values.
         unique_water_years (set): Set of unique water years in timeseries
         durations (List): List of durations - 1 value per year
@@ -3818,13 +3818,13 @@ def get_achievements(EWR_info:Dict, events:Dict, unique_water_years:set, duratio
     '''Returns a list of number of events per year.
     
     Args:
-        EWR_info (Dict): EWR parameters
+        EWR_info (Dict): ewr parameters
         events (Dict): Dictionary with water years as keys, and a list of event lists for values.
         unique_water_years (set): Set of unique water years in timeseries
         durations (List): List of durations - 1 value per year
 
     Results:
-        list: A list of years with the number of times the EWR requirements were achieved
+        list: A list of years with the number of times the ewr requirements were achieved
     '''
     events_filtered = filter_min_events(EWR_info, events)
     num_events = []
@@ -3868,7 +3868,7 @@ def get_number_events(EWR_info:Dict, events:Dict, unique_water_years:set, durati
     '''Returns a list of number of events per year
     
     Args:
-        EWR_info (Dict): EWR parameters
+        EWR_info (Dict): ewr parameters
         events (Dict): Dictionary with water years as keys, and a list of event lists for values.
         unique_water_years (set): Set of unique water years in timeseries
         durations (List): List of durations - 1 value per year
@@ -4187,15 +4187,15 @@ def get_total_series_days(water_years:List) -> pd.Series:
     
     return intoSeries
 
-def event_stats(df:pd.DataFrame, PU_df:pd.DataFrame, gauge:str, EWR:str, EWR_info:Dict, events:Dict, durations:List, water_years:List) -> pd.DataFrame:
+def event_stats(df:pd.DataFrame, PU_df:pd.DataFrame, gauge:str, ewr:str, EWR_info:Dict, events:Dict, durations:List, water_years:List) -> pd.DataFrame:
     ''' Produces statistics based on the event dictionaries and event gap dictionaries.
     
     Args:
         df (pd.DataFrame): Raw flow/level dataframe
         PU_df (pd.DataFrame): Dataframe with the results from the EWRs in the current planning unit
         gauge (str): current iteration gauge string
-        EWR (str): current iteration EWR string
-        EWR_info (Dict): Parameter information for current EWR
+        ewr (str): current iteration ewr string
+        EWR_info (Dict): Parameter information for current ewr
         events (Dict): Detailed event information events
         durations (List): List of annual required durations
         water_years (List): Daily water year values
@@ -4221,7 +4221,7 @@ def event_stats(df:pd.DataFrame, PU_df:pd.DataFrame, gauge:str, EWR:str, EWR_inf
     if EWR_info['flow_level_volume'] == 'V':
         years_with_events = get_event_years_volume_achieved(events, unique_water_years)
 
-    YWE = pd.Series(name = str(EWR + '_eventYears'), data = years_with_events, index = unique_water_years)
+    YWE = pd.Series(name = str(ewr + '_eventYears'), data = years_with_events, index = unique_water_years)
     # PU_df = pd.concat([PU_df, YWE], axis = 1)
     # Number of event achievements:
     num_event_achievements = get_achievements(EWR_info, events, unique_water_years, durations)
@@ -4229,63 +4229,63 @@ def event_stats(df:pd.DataFrame, PU_df:pd.DataFrame, gauge:str, EWR:str, EWR_inf
     if EWR_info['Code'] in ['rANA']:
         num_event_achievements = get_achievements_connecting_events(events, unique_water_years)
 
-    NEA = pd.Series(name = str(EWR + '_numAchieved'), data= num_event_achievements, index = unique_water_years)
+    NEA = pd.Series(name = str(ewr + '_numAchieved'), data= num_event_achievements, index = unique_water_years)
     # PU_df = pd.concat([PU_df, NEA], axis = 1)
     # Total number of events THIS ONE IS ONLY ACHIEVED due to Filter Applied
     num_events = get_number_events(EWR_info, events, unique_water_years, durations)
-    NE = pd.Series(name = str(EWR + '_numEvents'), data= num_events, index = unique_water_years)
+    NE = pd.Series(name = str(ewr + '_numEvents'), data= num_events, index = unique_water_years)
     # PU_df = pd.concat([PU_df, NE], axis = 1)
     # Total number of events THIS ONE IS ALL EVENTS
     num_events_all = get_all_events(events)
-    NEALL = pd.Series(name = str(EWR + '_numEventsAll'), data= num_events_all, index = unique_water_years)
+    NEALL = pd.Series(name = str(ewr + '_numEventsAll'), data= num_events_all, index = unique_water_years)
     # PU_df = pd.concat([PU_df, NEALL], axis = 1)
     # Max inter event period
     max_inter_period = get_max_inter_event_days(no_events, unique_water_years)
-    MIP = pd.Series(name = str(EWR + '_maxInterEventDays'), data= max_inter_period, index = unique_water_years)
+    MIP = pd.Series(name = str(ewr + '_maxInterEventDays'), data= max_inter_period, index = unique_water_years)
     # PU_df = pd.concat([PU_df, MIP], axis = 1)
     # Max inter event period achieved
     max_inter_period_achieved = get_event_max_inter_event_achieved(EWR_info, no_events, unique_water_years)
-    MIPA = pd.Series(name = str(EWR + '_maxInterEventDaysAchieved'), data= max_inter_period_achieved, index = unique_water_years)
+    MIPA = pd.Series(name = str(ewr + '_maxInterEventDaysAchieved'), data= max_inter_period_achieved, index = unique_water_years)
     # PU_df = pd.concat([PU_df, MIPA], axis = 1)
     # Average length of events
     av_length = get_average_event_length(events, unique_water_years)
-    AL = pd.Series(name = str(EWR + '_eventLength'), data = av_length, index = unique_water_years)
+    AL = pd.Series(name = str(ewr + '_eventLength'), data = av_length, index = unique_water_years)
     # PU_df = pd.concat([PU_df, AL], axis = 1)
     # Average length of events ONLY the ACHIEVED
     av_length_achieved = get_average_event_length_achieved(EWR_info, events)
-    ALA = pd.Series(name = str(EWR + '_eventLengthAchieved' ), data = av_length_achieved, index = unique_water_years)
+    ALA = pd.Series(name = str(ewr + '_eventLengthAchieved' ), data = av_length_achieved, index = unique_water_years)
     # PU_df = pd.concat([PU_df, ALA], axis = 1)
     # Total event days
     total_days = get_total_days(events, unique_water_years)
-    TD_A = pd.Series(name = str(EWR + '_totalEventDays'), data = total_days, index = unique_water_years)
+    TD_A = pd.Series(name = str(ewr + '_totalEventDays'), data = total_days, index = unique_water_years)
     # PU_df = pd.concat([PU_df, TD], axis = 1)
     # Total event days ACHIEVED
     total_days_achieved = get_achieved_event_days(EWR_info, events)
-    TDA = pd.Series(name = str(EWR + '_totalEventDaysAchieved'), data = total_days_achieved, index = unique_water_years)
+    TDA = pd.Series(name = str(ewr + '_totalEventDaysAchieved'), data = total_days_achieved, index = unique_water_years)
     # PU_df = pd.concat([PU_df, TDA], axis = 1)
     # Max event days
     max_days = get_max_event_days(events, unique_water_years)
-    MD = pd.Series(name = str(EWR + '_maxEventDays'), data = max_days, index = unique_water_years)
+    MD = pd.Series(name = str(ewr + '_maxEventDays'), data = max_days, index = unique_water_years)
     # PU_df = pd.concat([PU_df, MD], axis = 1)
     # Max rolling consecutive event days
     try:
         max_consecutive_days = get_max_consecutive_event_days(events, unique_water_years)
-        MR = pd.Series(name = str(EWR + '_maxRollingEvents'), data = max_consecutive_days, index = unique_water_years)
+        MR = pd.Series(name = str(ewr + '_maxRollingEvents'), data = max_consecutive_days, index = unique_water_years)
         # PU_df = pd.concat([PU_df, MR], axis = 1)
     except Exception as e:
         max_consecutive_days = [0]*len(unique_water_years)
-        MR = pd.Series(name = str(EWR + '_maxRollingEvents'), data = max_consecutive_days, index = unique_water_years)
+        MR = pd.Series(name = str(ewr + '_maxRollingEvents'), data = max_consecutive_days, index = unique_water_years)
         # PU_df = pd.concat([PU_df, MR], axis = 1)
         log.error(e)
     # Max rolling duration achieved
     achieved_max_rolling_duration = get_max_rolling_duration_achievement(durations, max_consecutive_days)
-    MRA = pd.Series(name = str(EWR + '_maxRollingAchievement'), data = achieved_max_rolling_duration, index = unique_water_years)
+    MRA = pd.Series(name = str(ewr + '_maxRollingAchievement'), data = achieved_max_rolling_duration, index = unique_water_years)
     # PU_df = pd.concat([PU_df, MRA], axis = 1)
     # Append information around available and missing data:
     yearly_gap = get_data_gap(df, water_years, gauge)
     total_days = get_total_series_days(water_years)
-    YG = pd.Series(name = str(EWR + '_missingDays'), data = yearly_gap, index = unique_water_years)
-    TD_B = pd.Series(name = str(EWR + '_totalPossibleDays'), data = total_days, index = unique_water_years)
+    YG = pd.Series(name = str(ewr + '_missingDays'), data = yearly_gap, index = unique_water_years)
+    TD_B = pd.Series(name = str(ewr + '_totalPossibleDays'), data = total_days, index = unique_water_years)
     # PU_df = pd.concat([PU_df, YG], axis = 1)
     # PU_df = pd.concat([PU_df, TD], axis = 1)
     PU_df = pd.concat(
@@ -4317,11 +4317,11 @@ def merge_weirpool_with_freshes(wp_freshes:List, PU_df:pd.DataFrame)-> pd.DataFr
     """Perform the post processing of WP2 and WP3 with equivalent freshes
 
     Args:
-        wp_freshes (List): freshed that need to be proceed to produced merged EWR
+        wp_freshes (List): freshed that need to be proceed to produced merged ewr
         PU_df (pd.DataFrame): Dataframe with all the statistics so for this calculation run
 
     Returns:
-        pd.DataFrame: Return Dataframe with the statistics of the merged EWR
+        pd.DataFrame: Return Dataframe with the statistics of the merged ewr
     """
 
     weirpool_pair = {'SF-WP':'WP3',
@@ -4451,41 +4451,41 @@ def find_function(ewr_key:str, new_config_file:dict) -> str:
 #---------------------------- Sorting and distributing to handling functions ---------------------#
 
 def calc_sorter(df_F:pd.DataFrame, df_L:pd.DataFrame, gauge:str, EWR_table:pd.DataFrame, calc_config: dict) -> tuple:
-    '''Sends to handling functions to get calculated depending on the type of EWR
+    '''Sends to handling functions to get calculated depending on the type of ewr
     
     Args:
         df_F (pd.DataFrame): Dataframe with the daily flows
         df_L (pd.DataFrame): Dataframe with the daily levels
         gauge (str): gauge string of current iteration
-        EWR_table (pd.DataFrame): Dataframe of EWR parameters
+        EWR_table (pd.DataFrame): Dataframe of ewr parameters
 
     Results:
         tuple[dict, dict]: annual results summary and detailed event information
     
     ''' 
-    # Get EWR tables:
+    # Get ewr tables:
     PU_items = EWR_table.groupby(['PlanningUnitID', 'PlanningUnitName']).size().reset_index().drop([0], axis=1)
-    # Extract relevant sections of the EWR table:
+    # Extract relevant sections of the ewr table:
     gauge_table = EWR_table[EWR_table['Gauge'] == gauge]
     # save the planning unit dataframes to this dictionary:
     location_results = {}
     location_events = {}
-    for PU in set(gauge_table['PlanningUnitID']):
-        PU_table = gauge_table[gauge_table['PlanningUnitID'] == PU]
+    for pu in set(gauge_table['PlanningUnitID']):
+        PU_table = gauge_table[gauge_table['PlanningUnitID'] == pu]
         EWR_categories = PU_table['FlowLevelVolume'].values
         EWR_codes = PU_table['Code']
         PU_df = pd.DataFrame()
         PU_events = {}
 
-        for i, EWR in enumerate(EWR_codes):
+        for i, ewr in enumerate(EWR_codes):
             events = {}
 
-            MULTIGAUGE = is_multigauge(EWR_table, gauge, EWR, PU)
+            MULTIGAUGE = is_multigauge(EWR_table, gauge, ewr, pu)
 
             # Save dict with function arguments value
-            all_args = {"PU": PU, 
+            all_args = {"pu": pu, 
             "gauge": gauge, 
-            "EWR": EWR, 
+            "ewr": ewr, 
             "EWR_table": EWR_table, 
             "df_F": df_F, 
             "df_L": df_L,
@@ -4494,7 +4494,7 @@ def calc_sorter(df_F:pd.DataFrame, df_L:pd.DataFrame, gauge:str, EWR_table:pd.Da
 
             cat = EWR_categories[i]
             gauge_calc_type = get_gauge_calc_type(MULTIGAUGE)
-            ewr_key = f'{EWR}-{gauge_calc_type}-{cat}'
+            ewr_key = f'{ewr}-{gauge_calc_type}-{cat}'
             function_name = find_function(ewr_key, calc_config)
             if function_name == 'unknown':
                 log.warning(f"skipping calculation due to ewr key {ewr_key} not in the configuration configuration files")
@@ -4508,13 +4508,13 @@ def calc_sorter(df_F:pd.DataFrame, df_L:pd.DataFrame, gauge:str, EWR_table:pd.Da
         
             PU_df, events = handle_function(**kwargs)
             if events != {}:
-                PU_events[str(EWR)]=events
+                PU_events[str(ewr)]=events
 
         # wp_freshes = [ewr for ewr in EWR_codes.to_list() if ewr in ["SF-WP","LF2-WP"]]
         # if wp_freshes:
         #     PU_df = merge_weirpool_with_freshes(wp_freshes, PU_df)
             
-        PU_name = PU_items['PlanningUnitName'].loc[PU_items[PU_items['PlanningUnitID'] == PU].index[0]]
+        PU_name = PU_items['PlanningUnitName'].loc[PU_items[PU_items['PlanningUnitID'] == pu].index[0]]
         
         location_results[PU_name] = PU_df
         location_events[PU_name] = PU_events

--- a/py_ewr/observed_handling.py
+++ b/py_ewr/observed_handling.py
@@ -331,11 +331,11 @@ class ObservedHandler:
 
         yearly_ewr_results = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=yearly_ewr_results,
-                                left_on=['Gauge','pu','ewrCode'],
+                                left_on=['Gauge','pu','Code'],
                                 selected_columns= ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll', 
                                             'eventLength', 'eventLengthAchieved', 'totalEventDays', 'totalEventDaysAchieved',
                                             'maxEventDays', 'maxRollingEvents', 'maxRollingAchievement',
-                                            'missingDays', 'totalPossibleDays', 'ewrCode',
+                                            'missingDays', 'totalPossibleDays', 'Code',
                                             'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
 

--- a/py_ewr/observed_handling.py
+++ b/py_ewr/observed_handling.py
@@ -228,8 +228,8 @@ class ObservedHandler:
 
         all_events = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=all_events,
-                                left_on=['gauge','pu','ewr'],
-                                selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                                left_on=['Gauge','pu','ewr'],
+                                selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                         'eventDuration', 'eventLength', 
                                         'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
@@ -248,8 +248,8 @@ class ObservedHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -276,8 +276,8 @@ class ObservedHandler:
 
         all_events_temp1 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp1,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -298,8 +298,8 @@ class ObservedHandler:
 
         all_events_temp2 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp2,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -331,12 +331,12 @@ class ObservedHandler:
 
         yearly_ewr_results = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=yearly_ewr_results,
-                                left_on=['gauge','pu','ewrCode'],
+                                left_on=['Gauge','pu','ewrCode'],
                                 selected_columns= ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll', 
                                             'eventLength', 'eventLengthAchieved', 'totalEventDays', 'totalEventDaysAchieved',
                                             'maxEventDays', 'maxRollingEvents', 'maxRollingAchievement',
                                             'missingDays', 'totalPossibleDays', 'ewrCode',
-                                            'scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
+                                            'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
 
         # Setting up the dictionary of yearly rolling maximum interevent periods:
@@ -345,8 +345,8 @@ class ObservedHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                                                 left_table=all_events_temp,
-                                                                left_on=['gauge', 'pu', 'ewr'],
-                                                                selected_columns=['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr',
+                                                                left_on=['Gauge', 'pu', 'ewr'],
+                                                                selected_columns=['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr',
                                                                                   'waterYear', 'startDate', 'endDate',
                                                                                   'eventDuration', 'eventLength',
                                                                                   'Multigauge'],

--- a/py_ewr/observed_handling.py
+++ b/py_ewr/observed_handling.py
@@ -228,8 +228,8 @@ class ObservedHandler:
 
         all_events = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=all_events,
-                                left_on=['Gauge','pu','ewr'],
-                                selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                                left_on=['Gauge','PlanningUnit','Code'],
+                                selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                         'eventDuration', 'eventLength', 
                                         'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
@@ -248,8 +248,8 @@ class ObservedHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -276,8 +276,8 @@ class ObservedHandler:
 
         all_events_temp1 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp1,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -298,8 +298,8 @@ class ObservedHandler:
 
         all_events_temp2 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp2,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -331,12 +331,12 @@ class ObservedHandler:
 
         yearly_ewr_results = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=yearly_ewr_results,
-                                left_on=['Gauge','pu','Code'],
+                                left_on=['Gauge','PlanningUnit','Code'],
                                 selected_columns= ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll', 
                                             'eventLength', 'eventLengthAchieved', 'totalEventDays', 'totalEventDaysAchieved',
                                             'maxEventDays', 'maxRollingEvents', 'maxRollingAchievement',
                                             'missingDays', 'totalPossibleDays', 'Code',
-                                            'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
+                                            'scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
 
         # Setting up the dictionary of yearly rolling maximum interevent periods:
@@ -345,8 +345,8 @@ class ObservedHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                                                 left_table=all_events_temp,
-                                                                left_on=['Gauge', 'pu', 'ewr'],
-                                                                selected_columns=['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr',
+                                                                left_on=['Gauge', 'PlanningUnit', 'Code'],
+                                                                selected_columns=['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code',
                                                                                   'waterYear', 'startDate', 'endDate',
                                                                                   'eventDuration', 'eventLength',
                                                                                   'Multigauge'],

--- a/py_ewr/parameter_metadata/obj2target.csv
+++ b/py_ewr/parameter_metadata/obj2target.csv
@@ -1,4 +1,4 @@
-planning_unit_name,LTWPShortName,env_obj,Specific_goal,Objective,Target,state,SWSDLName
+planning_unit_name,LTWPShortName,EnvObj,Specific_goal,Objective,Target,state,SWSDLName
 Mungindi to Boomi River Confluence,Barwon-Darling,NF1,All recorded fish species,No loss of native fish species,Native fish,NSW,Barwon-Darling Watercourse
 Mungindi to Boomi River Confluence,Barwon-Darling,EF1,Refugia,Provide & protect a diversity of refugia across the landscape,Priority ecosystem function,NSW,Barwon-Darling Watercourse
 Mungindi to Boomi River Confluence,Barwon-Darling,EF2,Habitat,"Create quality instream, floodplain & wetland habitat",Priority ecosystem function,NSW,Barwon-Darling Watercourse

--- a/py_ewr/parameter_metadata/obj2yrtarget.csv
+++ b/py_ewr/parameter_metadata/obj2yrtarget.csv
@@ -1,4 +1,4 @@
-env_obj,Target,Target_Category,Objective,target_5_year_2024,target_10_year_2029,target_20_year_2039
+EnvObj,Target,Target_Category,Objective,target_5_year_2024,target_10_year_2029,target_20_year_2039
 NF1,Native fish,,No loss of native fish species,All known species detected annually,All known species detected annually,All known species detected annually
 NF1,Native fish,,No loss of native fish species,,,Fish community status improved by one category compared to 2014 assessment
 NF2,Native fish,,Increase the distribution & abundance of short to moderate-lived generalist native fish species,Increased distribution & abundance of short to moderate-lived species compared to 2014 assessment,Increased distribution & abundance of short to moderate-lived species compared to 2014 assessment,Increased distribution & abundance of short to moderate-lived species compared to 2014 assessment

--- a/py_ewr/scenario_handling.py
+++ b/py_ewr/scenario_handling.py
@@ -972,9 +972,9 @@ class ScenarioHandler:
         For each unique ewr/pu/gauge - examines the ewr_results dataframe and if it exists here, then it is set to True in the logging_sheet dataframe.
         Create corresponding column in logging_sheet to log info.
         '''
-        results = self.ewr_results[["PlanningUnit", 'Gauge', "EwrCode"]].copy()
+        results = self.ewr_results[["PlanningUnit", 'Gauge', "Code"]].copy()
         results["Analysed?"] = True
-        self.logging_sheet = self.logging_sheet.merge(right = results, left_on=["PlanningUnitName", "Primary Gauge", "Code"], right_on=["PlanningUnit", 'Gauge', "EwrCode"], how="left")
+        self.logging_sheet = self.logging_sheet.merge(right = results, left_on=["PlanningUnitName", "Primary Gauge", "Code"], right_on=["PlanningUnit", 'Gauge', "Code"], how="left")
         self.logging_sheet["Analysed?"] = ~self.logging_sheet["Analysed?"].isna()
         self.logging_sheet['Gauge'] = self.logging_sheet["Gauge_x"].copy()
 

--- a/py_ewr/scenario_handling.py
+++ b/py_ewr/scenario_handling.py
@@ -809,8 +809,8 @@ class ScenarioHandler:
 
         all_events = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -829,8 +829,8 @@ class ScenarioHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -857,8 +857,8 @@ class ScenarioHandler:
 
         all_events_temp1 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp1,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -879,8 +879,8 @@ class ScenarioHandler:
 
         all_events_temp2 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp2,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -916,12 +916,12 @@ class ScenarioHandler:
                                 
         yearly_ewr_results = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=yearly_ewr_results,
-                                left_on=['Gauge','pu','Code'],
+                                left_on=['Gauge','PlanningUnit','Code'],
                                 selected_columns= ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
                                              'eventLength', 'eventLengthAchieved', 'totalEventDays', 'totalEventDaysAchieved',
                                             'maxEventDays', 'maxRollingEvents', 'maxRollingAchievement',
                                             'missingDays', 'totalPossibleDays', 'Code',
-                                            'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
+                                            'scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
 
         # Setting up the dictionary of yearly rolling maximum interevent periods:
@@ -930,8 +930,8 @@ class ScenarioHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp,
-                        left_on=['Gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','PlanningUnit','Code'],
+                        selected_columns= ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)

--- a/py_ewr/scenario_handling.py
+++ b/py_ewr/scenario_handling.py
@@ -44,7 +44,6 @@ def unpack_netcdf_as_dataframe(netcdf_file: str) -> pd.DataFrame:
         
         # Open the NetCDF file
         dataset = xr.open_dataset(netcdf_file, engine='netcdf4')
-        
         # Check if the dataset is empty
         if dataset is None:
             raise ValueError("NetCDF dataset is empty.")
@@ -368,7 +367,7 @@ def cleaner_netcdf_werp(input_df: pd.DataFrame, stations: dict,  ewr_table_path:
 
     # drop the values that don't map to a gauge (lots of nodes in iqqm don't)
         # This should be deprecated with the new way of choosing nodes on read-in, but being careful
-    cleaned_df = cleaned_df.query('gauge.notna()')
+    cleaned_df = cleaned_df.query('Gauge.notna()')
 
     # give each gauge its own column- that's what the tool expects
     cleaned_df = cleaned_df.pivot(columns = 'Gauge', values = 'Simulated flow')

--- a/py_ewr/scenario_handling.py
+++ b/py_ewr/scenario_handling.py
@@ -491,7 +491,7 @@ def match_MDBA_nodes(input_df: pd.DataFrame, model_metadata: pd.DataFrame, ewr_t
                         report.at[gauge, 'level'] = 'Y'
 
     if df_flow.empty and df_level.empty:
-        raise ValueError('No relevant gauges and or measurands found in dataset, the EWR tool cannot evaluate this model output file') 
+        raise ValueError('No relevant gauges and or measurands found in dataset, the ewr tool cannot evaluate this model output file') 
  
     # report.to_csv('report_v1.csv')  
     return df_flow, df_level, report
@@ -535,7 +535,7 @@ def match_MDBA_nodes(input_df: pd.DataFrame, model_metadata: pd.DataFrame, ewr_t
 #                         df_level[gauge] = input_df[col]
 
 #     if df_flow.empty and df_level.empty:
-#         raise ValueError('No relevant gauges and or measurands found in dataset, the EWR tool cannot evaluate this model output file')      
+#         raise ValueError('No relevant gauges and or measurands found in dataset, the ewr tool cannot evaluate this model output file')      
     
 #     df_flow.to_csv('existing_flow_mapped.csv')
 #     df_level.to_csv('existing_level_mapped.csv')
@@ -1049,16 +1049,16 @@ class ScenarioHandler:
             PU_items = self.logging_sheet.groupby(['PlanningUnitID', 'PlanningUnitName']).size().reset_index().drop([0], axis=1)
             gauge_table = self.logging_sheet[self.logging_sheet['Primary Gauge'] == gauge]
 
-            for PU in set(gauge_table['PlanningUnitID']):
+            for pu in set(gauge_table['PlanningUnitID']):
 
-                PU_table = gauge_table[gauge_table['PlanningUnitID'] == PU]
+                PU_table = gauge_table[gauge_table['PlanningUnitID'] == pu]
                 EWR_categories = PU_table['FlowLevelVolume'].values
                 EWR_codes = PU_table['Code']
 
-                for cat, EWR in zip(EWR_categories, EWR_codes):
+                for cat, ewr in zip(EWR_categories, EWR_codes):
 
                     ## CUSTOM MULTIGAUGE CHECK
-                    item = self.logging_sheet[(self.logging_sheet['Primary Gauge']==gauge) & (self.logging_sheet['Code']==EWR) & (self.logging_sheet['PlanningUnitID']==PU)]
+                    item = self.logging_sheet[(self.logging_sheet['Primary Gauge']==gauge) & (self.logging_sheet['Code']==ewr) & (self.logging_sheet['PlanningUnitID']==pu)]
                     item = item.replace({np.nan: None})
                     mg = item['Multigauge'].to_list()
 
@@ -1070,8 +1070,8 @@ class ScenarioHandler:
                         gauge_calc_type = 'multigauge'
                     ####
 
-                    ewr_key = f'{EWR}-{gauge_calc_type}-{cat}'
-                    self.logging_sheet.loc[((self.logging_sheet['Primary Gauge']==gauge) & (self.logging_sheet['Code']==EWR) & (self.logging_sheet['PlanningUnitID']==PU)), "EWR_key"] = ewr_key
+                    ewr_key = f'{ewr}-{gauge_calc_type}-{cat}'
+                    self.logging_sheet.loc[((self.logging_sheet['Primary Gauge']==gauge) & (self.logging_sheet['Code']==ewr) & (self.logging_sheet['PlanningUnitID']==pu)), "EWR_key"] = ewr_key
                     function_name = evaluate_EWRs.find_function(ewr_key, calc_config)                    
                     ewr_keys_in_parameter_sheet.append(ewr_key)
 

--- a/py_ewr/scenario_handling.py
+++ b/py_ewr/scenario_handling.py
@@ -363,7 +363,7 @@ def cleaner_netcdf_werp(input_df: pd.DataFrame, stations: dict,  ewr_table_path:
     cleaned_df = input_df.reset_index(level = 'node')
     cleaned_df['node'] = cleaned_df['node'].astype(str)
 
-    cleaned_df['gauge'] = cleaned_df['node'].map(stations)
+    cleaned_df['Gauge'] = cleaned_df['node'].map(stations)
     cleaned_df = cleaned_df.drop('node', axis = 1) 
 
     # drop the values that don't map to a gauge (lots of nodes in iqqm don't)
@@ -371,7 +371,7 @@ def cleaner_netcdf_werp(input_df: pd.DataFrame, stations: dict,  ewr_table_path:
     cleaned_df = cleaned_df.query('gauge.notna()')
 
     # give each gauge its own column- that's what the tool expects
-    cleaned_df = cleaned_df.pivot(columns = 'gauge', values = 'Simulated flow')
+    cleaned_df = cleaned_df.pivot(columns = 'Gauge', values = 'Simulated flow')
     cleaned_df.columns.name = None
 
     # the csvs return an 'object' type, not a datetime in the index
@@ -810,8 +810,8 @@ class ScenarioHandler:
 
         all_events = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -830,8 +830,8 @@ class ScenarioHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -858,8 +858,8 @@ class ScenarioHandler:
 
         all_events_temp1 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp1,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -880,8 +880,8 @@ class ScenarioHandler:
 
         all_events_temp2 = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp2,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -917,12 +917,12 @@ class ScenarioHandler:
                                 
         yearly_ewr_results = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=yearly_ewr_results,
-                                left_on=['gauge','pu','ewrCode'],
+                                left_on=['Gauge','pu','ewrCode'],
                                 selected_columns= ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
                                              'eventLength', 'eventLengthAchieved', 'totalEventDays', 'totalEventDaysAchieved',
                                             'maxEventDays', 'maxRollingEvents', 'maxRollingAchievement',
                                             'missingDays', 'totalPossibleDays', 'ewrCode',
-                                            'scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
+                                            'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
 
         # Setting up the dictionary of yearly rolling maximum interevent periods:
@@ -931,8 +931,8 @@ class ScenarioHandler:
 
         all_events_temp = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                         left_table=all_events_temp,
-                        left_on=['gauge','pu','ewr'],
-                        selected_columns= ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+                        left_on=['Gauge','pu','ewr'],
+                        selected_columns= ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                 'eventDuration', 'eventLength', 
                                 'Multigauge'],
                         parameter_sheet_path=self.parameter_sheet)
@@ -973,11 +973,11 @@ class ScenarioHandler:
         For each unique ewr/pu/gauge - examines the ewr_results dataframe and if it exists here, then it is set to True in the logging_sheet dataframe.
         Create corresponding column in logging_sheet to log info.
         '''
-        results = self.ewr_results[["PlanningUnit", "Gauge", "EwrCode"]].copy()
+        results = self.ewr_results[["PlanningUnit", 'Gauge', "EwrCode"]].copy()
         results["Analysed?"] = True
-        self.logging_sheet = self.logging_sheet.merge(right = results, left_on=["PlanningUnitName", "Primary Gauge", "Code"], right_on=["PlanningUnit", "Gauge", "EwrCode"], how="left")
+        self.logging_sheet = self.logging_sheet.merge(right = results, left_on=["PlanningUnitName", "Primary Gauge", "Code"], right_on=["PlanningUnit", 'Gauge', "EwrCode"], how="left")
         self.logging_sheet["Analysed?"] = ~self.logging_sheet["Analysed?"].isna()
-        self.logging_sheet["Gauge"] = self.logging_sheet["Gauge_x"].copy()
+        self.logging_sheet['Gauge'] = self.logging_sheet["Gauge_x"].copy()
 
     
     def log_if_node_in_siteID(self):
@@ -1000,7 +1000,7 @@ class ScenarioHandler:
         elif self.model_format == 'ten thousand year':
             pass
 
-        self.logging_sheet["node_in_siteID?"] = self.logging_sheet["Gauge"].isin(self.site_id_df["AWRC"].unique())
+        self.logging_sheet["node_in_siteID?"] = self.logging_sheet['Gauge'].isin(self.site_id_df["AWRC"].unique())
     
     def log_if_gauge_in_model_file(self):
         '''
@@ -1010,7 +1010,7 @@ class ScenarioHandler:
         site_id_in_model_file = [n for name in self.df_clean.columns for n in name.split("-")]
         self.site_id_df["IN_MODELFILE"] = self.site_id_df["SITEID"].isin(site_id_in_model_file)
         self.gauges_in_model_file = self.site_id_df[self.site_id_df.IN_MODELFILE]["AWRC"]
-        self.logging_sheet["gauge_in_model_file?"] = self.logging_sheet["Gauge"].isin(self.gauges_in_model_file)
+        self.logging_sheet["gauge_in_model_file?"] = self.logging_sheet['Gauge'].isin(self.gauges_in_model_file)
     
     def log_measurand_info(self):
         '''
@@ -1019,9 +1019,9 @@ class ScenarioHandler:
         '''
         self.logging_sheet.loc[:, "gaugeANDmeasurand_in_model_file? (Yes/No)"] = False
 
-        for idx, row in self.logging_sheet[["Gauge", "GaugeType"]].drop_duplicates().iterrows():
+        for idx, row in self.logging_sheet[['Gauge', "GaugeType"]].drop_duplicates().iterrows():
 
-            gauge = row["Gauge"]
+            gauge = row['Gauge']
             gauge_type = row["GaugeType"]
 
             if gauge_type == 'F':
@@ -1096,14 +1096,14 @@ class ScenarioHandler:
         # spare_siteID_df = spare_siteID_df.groupby("AWRC").agg({'SITEID': lambda x: list(x)})
         spare_siteID_df = spare_siteID_df.rename(columns={"SITEID": "spare_SITEID"})
 
-        self.logging_sheet = self.logging_sheet.merge(right = spare_siteID_df, left_on=["Gauge"], right_index=True, how="left")
+        self.logging_sheet = self.logging_sheet.merge(right = spare_siteID_df, left_on=['Gauge'], right_index=True, how="left")
 
         ### section to add the used SITEID
         used_siteID_df = self.site_id_df[self.site_id_df.IN_MODELFILE][["AWRC", "SITEID"]]
         used_siteID_df = used_siteID_df.rename(columns={"SITEID": "matched_SITEID"})
         used_siteID_df = used_siteID_df.set_index("AWRC")
 
-        self.logging_sheet = self.logging_sheet.merge(right = used_siteID_df, left_on=["Gauge"], right_index=True, how="left")
+        self.logging_sheet = self.logging_sheet.merge(right = used_siteID_df, left_on=['Gauge'], right_index=True, how="left")
         
         # mark spare_SITEID column of those that dont have more than one SITEID to match with as EXACT MATCHES
         self.logging_sheet.loc[~self.logging_sheet.matched_SITEID.isna() & self.logging_sheet.spare_SITEID.isna(), "spare_SITEID"] = "EXACT_MATCH"
@@ -1120,7 +1120,7 @@ class ScenarioHandler:
         for counter, (idx, row) in enumerate(rows_to_duplicate.iterrows()):
             updated_idx = counter + idx # update idx to account for all inserted rows
             duplicate_row = logging_sheet.loc[updated_idx, :].copy()
-            duplicate_row["Gauge"] = logging_sheet.loc[updated_idx, "Multigauge"]
+            duplicate_row['Gauge'] = logging_sheet.loc[updated_idx, "Multigauge"]
             logging_sheet = pd.DataFrame(np.insert(logging_sheet.values, updated_idx+1, values=duplicate_row.values, axis=0), columns=logging_sheet.columns)
 
         ## Weirpool
@@ -1130,7 +1130,7 @@ class ScenarioHandler:
         for counter, (idx, row) in enumerate(rows_to_duplicate.iterrows()):
             updated_idx = counter + idx # update idx to account for all inserted rows
             duplicate_row = logging_sheet.loc[updated_idx, :].copy()
-            duplicate_row["Gauge"] = logging_sheet.loc[updated_idx, "WeirpoolGauge"]
+            duplicate_row['Gauge'] = logging_sheet.loc[updated_idx, "WeirpoolGauge"]
             duplicate_row["GaugeType"] = "L"
             logging_sheet = pd.DataFrame(np.insert(logging_sheet.values, updated_idx+1, values=duplicate_row.values, axis=0), columns=logging_sheet.columns)   
 
@@ -1154,7 +1154,7 @@ class ScenarioHandler:
                 duplicate_row = logging_sheet.loc[updated_idx, :].copy()
 
                 rows_to_insert = pd.DataFrame([duplicate_row] * len(gauge_list))
-                rows_to_insert["Gauge"] = gauge_list
+                rows_to_insert['Gauge'] = gauge_list
 
                 logging_sheet.drop(index=updated_idx, axis=0, inplace=True)
 
@@ -1171,7 +1171,7 @@ class ScenarioHandler:
         """
         parameter_sheet = pd.read_csv(self.parameter_sheet)
 
-        self.logging_sheet = parameter_sheet.copy()[["PlanningUnitName", "Code", "Gauge", "GaugeType", 'PlanningUnitID', 'FlowLevelVolume', "Multigauge", "WeirpoolGauge"]]
+        self.logging_sheet = parameter_sheet.copy()[["PlanningUnitName", "Code", 'Gauge', "GaugeType", 'PlanningUnitID', 'FlowLevelVolume', "Multigauge", "WeirpoolGauge"]]
 
         self.logging_sheet = self.create_multi_index(self.logging_sheet)
 
@@ -1182,7 +1182,7 @@ class ScenarioHandler:
         self.log_calc_config_info()
         self.log_siteID_info()
 
-        self.logging_sheet = self.logging_sheet[["PlanningUnitName", "Code", "Primary Gauge", "Gauge", "GaugeType", "is_in_calc_config?", "node_in_siteID?", "gauge_in_model_file?", "gaugeANDmeasurand_in_model_file? (Yes/No)", "matched_SITEID", "spare_SITEID", "Analysed?"]]
+        self.logging_sheet = self.logging_sheet[["PlanningUnitName", "Code", "Primary Gauge", 'Gauge', "GaugeType", "is_in_calc_config?", "node_in_siteID?", "gauge_in_model_file?", "gaugeANDmeasurand_in_model_file? (Yes/No)", "matched_SITEID", "spare_SITEID", "Analysed?"]]
 
         return self.logging_sheet
     

--- a/py_ewr/scenario_handling.py
+++ b/py_ewr/scenario_handling.py
@@ -916,11 +916,11 @@ class ScenarioHandler:
                                 
         yearly_ewr_results = summarise_results.join_ewr_parameters(cols_to_add=['Multigauge', 'State', 'SWSDLName'],
                                 left_table=yearly_ewr_results,
-                                left_on=['Gauge','pu','ewrCode'],
+                                left_on=['Gauge','pu','Code'],
                                 selected_columns= ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
                                              'eventLength', 'eventLengthAchieved', 'totalEventDays', 'totalEventDaysAchieved',
                                             'maxEventDays', 'maxRollingEvents', 'maxRollingAchievement',
-                                            'missingDays', 'totalPossibleDays', 'ewrCode',
+                                            'missingDays', 'totalPossibleDays', 'Code',
                                             'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge'],
                                 parameter_sheet_path=self.parameter_sheet)
 

--- a/py_ewr/summarise_results.py
+++ b/py_ewr/summarise_results.py
@@ -371,7 +371,7 @@ def sum_0(series:pd.Series) -> int:
 
 def summarise(input_dict:Dict , events:Dict, parameter_sheet_path:str = None)-> pd.DataFrame:
     """orchestrate the processing of the pu_dfs items and the gauge events and join
-    in one summary DataFrame and join with EWR parameters for comparison
+    in one summary DataFrame and join with ewr parameters for comparison
 
     Args:
         input_dict (Dict): DataFrame result by yearly with statistics for the ewr calculations.
@@ -558,7 +558,7 @@ def events_to_interevents(start_date: date, end_date: date, df_events: pd.DataFr
             # Remove 0 length entries (these can happen if there was an event on the first or last day of timeseries)
             df_subset = df_subset.drop(df_subset[df_subset.interEventLength == 0].index)
             
-            # Add the EWR interevents onto the main dataframe:
+            # Add the ewr interevents onto the main dataframe:
             all_interEvents = pd.concat([all_interEvents, df_subset], ignore_index=True)
 
     # Remove the ID column before returning
@@ -595,7 +595,7 @@ def filter_successful_events(all_events: pd.DataFrame, ewr_table_path: str = Non
         pu = i.split('TEMPORARY_ID_SPLIT')[2]
         ewr = i.split('TEMPORARY_ID_SPLIT')[3]      
 
-        # Pull EWR minSpell value from EWR dataset
+        # Pull ewr minSpell value from ewr dataset
         minSpell = int(data_inputs.ewr_parameter_grabber(EWR_table, gauge, pu, ewr, 'MinSpell'))
         # Filter out the events that fall under the minimum spell length
         df_subset = df_subset.drop(df_subset[df_subset.eventDuration < minSpell].index)
@@ -612,7 +612,7 @@ def get_rolling_max_interEvents(df:pd.DataFrame, start_date: date, end_date: dat
         start_date: Not used TODO: delete
         end_date: Not used TODO: delete
         yearly_df (pd.DataFrame): used to get list of all EWRs
-        ewr_table_path: where to pull the EWR table from (local or custom)
+        ewr_table_path: where to pull the ewr table from (local or custom)
     Results:
         pd.DataFrame: 
     
@@ -625,12 +625,12 @@ def get_rolling_max_interEvents(df:pd.DataFrame, start_date: date, end_date: dat
     unique_ID = list(OrderedDict.fromkeys(yearly_df['ID']))
     master_dict = dict()
     unique_years = list(range(min(yearly_df['Year']),max(yearly_df['Year'])+1,1))
-    # Load in EWR table to variable to access start and end dates of the EWR
+    # Load in ewr table to variable to access start and end dates of the ewr
     EWR_table, bad_EWRs = data_inputs.get_EWR_table(ewr_table_path)
     for unique_EWR in unique_ID:
         df_subset = df[df['ID'] == unique_EWR]
         yearly_df_subset = yearly_df[yearly_df['ID'] == unique_EWR]
-        # Get EWR characteristics for current EWR
+        # Get ewr characteristics for current ewr
         scenario = unique_EWR.split('TEMPORARY_ID_SPLIT')[0]
         gauge = unique_EWR.split('TEMPORARY_ID_SPLIT')[1]
         pu = unique_EWR.split('TEMPORARY_ID_SPLIT')[2]
@@ -653,7 +653,7 @@ def get_rolling_max_interEvents(df:pd.DataFrame, start_date: date, end_date: dat
             master_dict[scenario][gauge][pu] = {}
         if ewr not in master_dict[scenario][gauge][pu]:
             master_dict[scenario][gauge][pu][ewr] = evaluate_EWRs.construct_event_dict(unique_years)
-        # Pull EWR start and end date from EWR dataset and clean
+        # Pull ewr start and end date from ewr dataset and clean
         EWR_info = {}
         EWR_info['start_month'] = evaluate_EWRs.component_pull(EWR_table, gauge, pu, ewr, 'StartMonth', pu_ID=False)
         EWR_info['end_month'] = evaluate_EWRs.component_pull(EWR_table, gauge, pu, ewr, 'EndMonth', pu_ID=False)
@@ -671,7 +671,7 @@ def get_rolling_max_interEvents(df:pd.DataFrame, start_date: date, end_date: dat
         #         current_date += timedelta(days=1)
 
         #--------------
-        # Iterate over the interevent periods for this EWR
+        # Iterate over the interevent periods for this ewr
         for i, row in df_subset.iterrows():
             # Get the date range:
             period = pd.period_range(row['startDate'],row['endDate'])
@@ -697,7 +697,7 @@ def add_interevent_to_yearly_results(yearly_df: pd.DataFrame, yearly_dict:Dict) 
 
     Args:
         yearly_df (pd.DataFrame): Yearly results dataframe summary
-        yearly_dict (dict): Rolling maximum annual interevent period for every EWR
+        yearly_dict (dict): Rolling maximum annual interevent period for every ewr
     Returns:
         pd.DataFrame: Yearly results dataframe summary with the new column
     '''
@@ -719,7 +719,7 @@ def add_interevent_to_yearly_results(yearly_df: pd.DataFrame, yearly_dict:Dict) 
 
 def add_interevent_check_to_yearly_results(yearly_df: pd.DataFrame, ewr_table_path: str = None) -> pd.DataFrame:
     '''
-    For each EWR, check to see if the rolling max interevent achieves the minimum requirement.
+    For each ewr, check to see if the rolling max interevent achieves the minimum requirement.
 
     Args:
         yearly_df (pd.DataFrame): 
@@ -730,10 +730,10 @@ def add_interevent_check_to_yearly_results(yearly_df: pd.DataFrame, ewr_table_pa
 
     yearly_df['rollingMaxInterEventAchieved'] = None
 
-    # Load in EWR table to variable to access start and end dates of the EWR
+    # Load in ewr table to variable to access start and end dates of the ewr
     EWR_table, bad_EWRs = data_inputs.get_EWR_table(ewr_table_path)
 
-    # Get EWR characteristics for current EWR
+    # Get ewr characteristics for current ewr
     for i, row in yearly_df.iterrows():
         gauge = yearly_df.loc[i, 'Gauge']
         pu = yearly_df.loc[i, 'pu']

--- a/py_ewr/summarise_results.py
+++ b/py_ewr/summarise_results.py
@@ -44,7 +44,7 @@ def get_ewr_columns(ewr:str, cols:List) -> List:
 
 
 def get_columns_attributes(cols: List)-> List:
-    """Takes a list of columns with the pattern EwrCode_Attribute
+    """Takes a list of columns with the pattern Code_Attribute
     and relates them returning only the Attribute name.
 
     Args:
@@ -435,7 +435,7 @@ def summarise(input_dict:Dict , events:Dict, parameter_sheet_path:str = None)-> 
                                                     'MaxInter-event',
                                                     'NoDataDays',
                                                     'TotalDays'],
-                                renamed_columns=['Scenario','Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'EwrCode', 'Multigauge','EventYears', 'Frequency', 'TargetFrequency',
+                                renamed_columns=['Scenario','Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'Multigauge','EventYears', 'Frequency', 'TargetFrequency',
                                     'AchievementCount', 'AchievementPerYear', 'EventCount', 'EventCountAll','EventsPerYear', 'EventsPerYearAll',
                                     'AverageEventLength', 'ThresholdDays', #'InterEventExceedingCount',
                                     'MaxInterEventYears', 'NoDataDays', 'TotalDays'],

--- a/py_ewr/summarise_results.py
+++ b/py_ewr/summarise_results.py
@@ -75,7 +75,7 @@ def pu_dfs_to_process(detailed_results: Dict)-> List[Dict]:
     Each item is a dictionary with the following keys.
                 { "scenario" : scenario_name,
                   'Gauge' : gauge_id,
-                  "pu" : pu_name,
+                  "PlanningUnit" : pu_name,
                   "pu_df : DataFrame}
 
     Args:
@@ -85,7 +85,7 @@ def pu_dfs_to_process(detailed_results: Dict)-> List[Dict]:
             }
 
         } 
-        It packs in a dictionary all the gauge ewr calculation for the scenario
+        It packs in a dictionary all the gauge Code calculation for the scenario
         or observed dates run.
 
     Returns:
@@ -98,19 +98,19 @@ def pu_dfs_to_process(detailed_results: Dict)-> List[Dict]:
                 item = {}
                 item["scenario"] = scenario
                 item['Gauge'] = gauge
-                item["pu"] = pu
+                item["PlanningUnit"] = pu
                 item["pu_df"] = detailed_results[scenario][gauge][pu]
                 items_to_process.append(item)
     return items_to_process
 
 
-def process_df(scenario:str, Gauge:str, pu:str, pu_df: pd.DataFrame)-> pd.DataFrame:
+def process_df(scenario:str, Gauge:str, PlanningUnit:str, pu_df: pd.DataFrame)-> pd.DataFrame:
     """Process all the pu_dfs into a tidy format
 
     Args:
         scenario (str): scenario name metadata
-        gauge (str): gauge name metadata
-        pu (str): planning unit name metadata
+        Gauge (str): gauge name metadata
+        PlanningUnit (str): planning unit name metadata
         pu_df (pd.DataFrame): DataFrame to be transformed
 
     Returns:
@@ -127,7 +127,7 @@ def process_df(scenario:str, Gauge:str, pu:str, pu_df: pd.DataFrame)-> pd.DataFr
         ewr_df["Code"] = ewr
         ewr_df["scenario"] = scenario
         ewr_df['Gauge'] = Gauge
-        ewr_df["pu"] = pu
+        ewr_df["PlanningUnit"] = PlanningUnit
         ewr_df = ewr_df.loc[:,~ewr_df.columns.duplicated()]
         returned_dfs.append(ewr_df)
     return pd.concat(returned_dfs, ignore_index=True)
@@ -153,17 +153,17 @@ def process_df_results(results_to_process: List[Dict])-> pd.DataFrame:
     return pd.concat(returned_dfs, ignore_index=True)
 
 def get_events_to_process(gauge_events: dict)-> List:
-    """Take the detailed gauge events results dictionary of the ewr calculation run,
+    """Take the detailed gauge events results dictionary of the Code calculation run,
     and unpack items into a list of items.
     Each item is a dictionary with the following keys.
                 { "scenario" : scenario_name,
                   'Gauge' : gauge_id,
-                  "pu" : pu_name,
-                  "ewr": ewr
+                  "PlanningUnit" : pu_name,
+                  "Code": Code
                   "ewr_events" : yearly_events_dictionary}
 
     Args:
-        gauge_events (dict): Gauge events captured by the ewr calculations.
+        gauge_events (dict): Gauge events captured by the Code calculations.
         Dictionary with the following structure
         {'observed': {'419001': {'Keepit to Boggabri': {'CF1_a': ({2010: [],
                 2011: [],
@@ -173,7 +173,7 @@ def get_events_to_process(gauge_events: dict)-> List:
                                 }
                      }
         }
-        It packs in a dictionary all the gauge ewr yearly events and threshold flows.
+        It packs in a dictionary all the gauge Code yearly events and threshold flows.
 
     Returns:
         List: list of dict with the items to be processed
@@ -191,8 +191,8 @@ def get_events_to_process(gauge_events: dict)-> List:
                         item = {}
                         item["scenario"] = scenario
                         item['Gauge'] = gauge
-                        item["pu"] = pu
-                        item["ewr"] = ewr
+                        item["PlanningUnit"] = pu
+                        item["Code"] = ewr
                         item["ewr_events"],  = gauge_events[scenario][gauge][pu][ewr]
                         items_to_process.append(item)
                     except Exception as e:
@@ -226,14 +226,14 @@ def sum_events(yearly_events:dict)-> int:
     return len(list(chain(*flattened_events)))
 
 
-def process_yearly_events(scenario:str, Gauge:str, pu:str, ewr:str, ewr_events: Dict)-> pd.DataFrame:
+def process_yearly_events(scenario:str, Gauge:str, PlanningUnit:str, Code:str, ewr_events: Dict)-> pd.DataFrame:
     """process each item for the gauge and return the statistics in a DataFrame
 
     Args:
         scenario (str): scenario name metadata
         gauge (str): gauge name metadata
-        pu (str): planning unit name metadata
-        ewr (str): DataFrame to be transformed
+        PlanningUnit (str): planning unit name metadata
+        Code (str): DataFrame to be transformed
         ewr_events (Dict): Dict with all yearly events list with date and flow/level 
 
     Returns:
@@ -246,8 +246,8 @@ def process_yearly_events(scenario:str, Gauge:str, pu:str, ewr:str, ewr_events: 
     average_event_length = total_event_days/total_events if total_events else 0
     row_data['scenario'].append(scenario)
     row_data['Gauge'].append(Gauge)
-    row_data['pu'].append(pu)
-    row_data['Code'].append(ewr)
+    row_data['PlanningUnit'].append(PlanningUnit)
+    row_data['Code'].append(Code)
     row_data['totalEvents'].append(total_events)
     row_data['totalEventDays'].append(total_event_days)
     row_data['averageEventLength'].append(average_event_length)
@@ -270,20 +270,20 @@ def process_ewr_events_stats(events_to_process: List[Dict])-> pd.DataFrame:
         returned_dfs.append(row_data)
     return pd.concat(returned_dfs, ignore_index=True)
 
-def process_all_yearly_events(scenario:str, Gauge:str, pu:str, ewr:str, ewr_events: Dict)-> pd.DataFrame():
+def process_all_yearly_events(scenario:str, Gauge:str, PlanningUnit:str, Code:str, ewr_events: Dict)-> pd.DataFrame():
     """process each item for the gauge and return all events. Each event is a row with a start and end date
     duration and event length
 
     Args:
         scenario (str): scenario name metadata
         gauge (str): gauge name metadata
-        pu (str): planning unit name metadata
-        ewr (str): DataFrame to be transformed
+        PlanningUnit (str): planning unit name metadata
+        Code (str): DataFrame to be transformed
         ewr_events (Dict): Dict with all yearly events list with date and flow/level
         
 
     Returns:
-        pd.DataFrame: DataFrame with all events of Pu-ewr-gauge combination
+        pd.DataFrame: DataFrame with all events of Pu-Code-gauge combination
     """
     df_data = defaultdict(list)
     for year in ewr_events:
@@ -292,8 +292,8 @@ def process_all_yearly_events(scenario:str, Gauge:str, pu:str, ewr:str, ewr_even
             end_date, _ = ev[-1]
             df_data["scenario"].append(scenario)
             df_data['Gauge'].append(Gauge)
-            df_data["pu"].append(pu)
-            df_data["ewr"].append(ewr)
+            df_data["PlanningUnit"].append(PlanningUnit)
+            df_data["Code"].append(Code)
             df_data["waterYear"].append(year)
             df_data["startDate"].append(start_date )
             df_data["endDate"].append(end_date)
@@ -383,9 +383,9 @@ def summarise(input_dict:Dict , events:Dict, parameter_sheet_path:str = None)-> 
     to_process = pu_dfs_to_process(input_dict)
     yearly_ewr_results = process_df_results(to_process)
     
-    # aggregate by 'Gauge',"pu","Code"
+    # aggregate by 'Gauge',"PlanningUnit","Code"
     final_summary_output = (yearly_ewr_results
-    .groupby(["scenario",'Gauge',"pu","Code"])
+    .groupby(["scenario",'Gauge',"PlanningUnit","Code"])
     .agg( EventYears = ("eventYears", 'sum'),
           Frequency = ("eventYears", get_frequency),
           AchievementCount = ("numAchieved", 'sum'),
@@ -409,15 +409,15 @@ def summarise(input_dict:Dict , events:Dict, parameter_sheet_path:str = None)-> 
     
     final_summary_output = final_summary_output.merge(ewr_event_stats, 
                                                       'left',
-                                                      left_on=['scenario', 'Gauge','pu','Code'], 
-                                                      right_on=['scenario', 'Gauge','pu',"Code"])
+                                                      left_on=['scenario', 'Gauge','PlanningUnit','Code'], 
+                                                      right_on=['scenario', 'Gauge','PlanningUnit',"Code"])
     # Join Ewr parameter to summary
 
     final_merged = join_ewr_parameters(cols_to_add=['TargetFrequency','MaxInter-event','Multigauge', 'State', 'SWSDLName'],
                                 left_table=final_summary_output,
-                                left_on=['Gauge','pu','Code'],
+                                left_on=['Gauge','PlanningUnit','Code'],
                                 selected_columns=["scenario",'Gauge',
-                                                    'pu', 'State', 'SWSDLName', 
+                                                    'PlanningUnit', 'State', 'SWSDLName', 
                                                     'Code',
                                                     'Multigauge',
                                                     'EventYears',
@@ -458,7 +458,7 @@ def filter_duplicate_start_dates(df: pd.DataFrame) -> pd.DataFrame:
 
     '''
 
-    df.drop_duplicates(subset = ['scenario', 'Gauge', 'pu', 'ewr', 'startDate'], keep='last', inplace=True)
+    df.drop_duplicates(subset = ['scenario', 'Gauge', 'PlanningUnit', 'Code', 'startDate'], keep='last', inplace=True)
 
     return df
 
@@ -504,9 +504,9 @@ def events_to_interevents(start_date: date, end_date: date, df_events: pd.DataFr
     
     '''
     # Create the unique ID field
-    df_events['ID'] = df_events['scenario']+df_events['Gauge']+df_events['pu']+df_events['ewr']
+    df_events['ID'] = df_events['scenario']+df_events['Gauge']+df_events['PlanningUnit']+df_events['Code']
     unique_ID = df_events['ID'].unique()
-    all_interEvents = pd.DataFrame(columns = ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'ID', 
+    all_interEvents = pd.DataFrame(columns = ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'ID', 
                                                 'startDate', 'endDate', 'interEventLength'])
 
     for i in unique_ID:
@@ -528,13 +528,13 @@ def events_to_interevents(start_date: date, end_date: date, df_events: pd.DataFr
             # Create the new dataframe:
             new_scenario = [contain_values['scenario'].iloc[0]]*length
             new_gauge = [contain_values['Gauge'].iloc[0]]*length
-            new_pu = [contain_values['pu'].iloc[0]]*length
+            new_pu = [contain_values['PlanningUnit'].iloc[0]]*length
             new_state = [contain_values['State'].iloc[0]]*length
             new_sdl = [contain_values['SWSDLName'].iloc[0]]*length
-            new_ewr = [contain_values['ewr'].iloc[0]]*length
+            new_ewr = [contain_values['Code'].iloc[0]]*length
             new_ID = [contain_values['ID'].iloc[0]]*length
 
-            data = {'scenario': new_scenario, 'Gauge': new_gauge, 'pu': new_pu, 'State': new_state, 'SWSDLName': new_sdl, 'ewr': new_ewr, 'ID': new_ID, 'startDate': inter_starts, 'endDate': inter_ends}
+            data = {'scenario': new_scenario, 'Gauge': new_gauge, 'PlanningUnit': new_pu, 'State': new_state, 'SWSDLName': new_sdl, 'Code': new_ewr, 'ID': new_ID, 'startDate': inter_starts, 'endDate': inter_ends}
 
             df_subset = pd.DataFrame(data=data)
 
@@ -581,10 +581,10 @@ def filter_successful_events(all_events: pd.DataFrame, ewr_table_path: str = Non
 
     s = 'TEMPORARY_ID_SPLIT'
 
-    all_events['ID'] = all_events['scenario']+s+all_events['Gauge']+s+all_events['pu']+s+all_events['ewr']
+    all_events['ID'] = all_events['scenario']+s+all_events['Gauge']+s+all_events['PlanningUnit']+s+all_events['Code']
     unique_ID = list(OrderedDict.fromkeys(all_events['ID']))
     EWR_table, bad_EWRs = data_inputs.get_EWR_table(ewr_table_path)
-    all_successfulEvents = pd.DataFrame(columns = ['scenario', 'Gauge', 'pu', 'ewr', 'waterYear', 'startDate', 'endDate', 'eventDuration', 'eventLength', 'multigauge' 'ID'])
+    all_successfulEvents = pd.DataFrame(columns = ['scenario', 'Gauge', 'PlanningUnit', 'Code', 'waterYear', 'startDate', 'endDate', 'eventDuration', 'eventLength', 'multigauge' 'ID'])
     
     # Filter out unsuccesful events
     # Iterate over the all_events dataframe
@@ -620,8 +620,8 @@ def get_rolling_max_interEvents(df:pd.DataFrame, start_date: date, end_date: dat
 
     s = 'TEMPORARY_ID_SPLIT'
 
-    df['ID'] = df['scenario']+s+df['Gauge']+s+df['pu']+s+df['ewr']
-    yearly_df['ID'] = yearly_df['scenario']+s+yearly_df['Gauge']+s+yearly_df['pu']+s+yearly_df['Code']
+    df['ID'] = df['scenario']+s+df['Gauge']+s+df['PlanningUnit']+s+df['Code']
+    yearly_df['ID'] = yearly_df['scenario']+s+yearly_df['Gauge']+s+yearly_df['PlanningUnit']+s+yearly_df['Code']
     unique_ID = list(OrderedDict.fromkeys(yearly_df['ID']))
     master_dict = dict()
     unique_years = list(range(min(yearly_df['Year']),max(yearly_df['Year'])+1,1))
@@ -710,7 +710,7 @@ def add_interevent_to_yearly_results(yearly_df: pd.DataFrame, yearly_dict:Dict) 
             continue
         scenario = yearly_df.loc[i, 'scenario']
         gauge = yearly_df.loc[i, 'Gauge']
-        pu = yearly_df.loc[i, 'pu']
+        pu = yearly_df.loc[i, 'PlanningUnit']
         year = yearly_df.loc[i, 'Year']
         value_to_add = yearly_dict[scenario][gauge][pu][ewr][year]
         yearly_df.loc[i, 'rollingMaxInterEvent'] = value_to_add
@@ -736,7 +736,7 @@ def add_interevent_check_to_yearly_results(yearly_df: pd.DataFrame, ewr_table_pa
     # Get ewr characteristics for current ewr
     for i, row in yearly_df.iterrows():
         gauge = yearly_df.loc[i, 'Gauge']
-        pu = yearly_df.loc[i, 'pu']
+        pu = yearly_df.loc[i, 'PlanningUnit']
         ewr = yearly_df.loc[i, 'Code']
 
         if '/' in ewr:

--- a/py_ewr/summarise_results.py
+++ b/py_ewr/summarise_results.py
@@ -159,7 +159,7 @@ def get_events_to_process(gauge_events: dict)-> List:
                 { "scenario" : scenario_name,
                   'Gauge' : gauge_id,
                   "pu" : pu_name,
-                  "ewr": ewr_code
+                  "ewr": ewr
                   "ewr_events" : yearly_events_dictionary}
 
     Args:

--- a/py_ewr/summarise_results.py
+++ b/py_ewr/summarise_results.py
@@ -74,7 +74,7 @@ def pu_dfs_to_process(detailed_results: Dict)-> List[Dict]:
     either observed or scenario and unpack items into a list of items.
     Each item is a dictionary with the following keys.
                 { "scenario" : scenario_name,
-                  "gauge" : gauge_id,
+                  'Gauge' : gauge_id,
                   "pu" : pu_name,
                   "pu_df : DataFrame}
 
@@ -97,14 +97,14 @@ def pu_dfs_to_process(detailed_results: Dict)-> List[Dict]:
             for pu in detailed_results[scenario][gauge]:
                 item = {}
                 item["scenario"] = scenario
-                item["gauge"] = gauge
+                item['Gauge'] = gauge
                 item["pu"] = pu
                 item["pu_df"] = detailed_results[scenario][gauge][pu]
                 items_to_process.append(item)
     return items_to_process
 
 
-def process_df(scenario:str, gauge:str, pu:str, pu_df: pd.DataFrame)-> pd.DataFrame:
+def process_df(scenario:str, Gauge:str, pu:str, pu_df: pd.DataFrame)-> pd.DataFrame:
     """Process all the pu_dfs into a tidy format
 
     Args:
@@ -126,7 +126,7 @@ def process_df(scenario:str, gauge:str, pu:str, pu_df: pd.DataFrame)-> pd.DataFr
         ewr_df = ewr_df.reset_index().rename(columns={"index":'Year'})
         ewr_df["ewrCode"] = ewr
         ewr_df["scenario"] = scenario
-        ewr_df["gauge"] = gauge
+        ewr_df['Gauge'] = Gauge
         ewr_df["pu"] = pu
         ewr_df = ewr_df.loc[:,~ewr_df.columns.duplicated()]
         returned_dfs.append(ewr_df)
@@ -157,7 +157,7 @@ def get_events_to_process(gauge_events: dict)-> List:
     and unpack items into a list of items.
     Each item is a dictionary with the following keys.
                 { "scenario" : scenario_name,
-                  "gauge" : gauge_id,
+                  'Gauge' : gauge_id,
                   "pu" : pu_name,
                   "ewr": ewr_code
                   "ewr_events" : yearly_events_dictionary}
@@ -190,7 +190,7 @@ def get_events_to_process(gauge_events: dict)-> List:
                     try:
                         item = {}
                         item["scenario"] = scenario
-                        item["gauge"] = gauge
+                        item['Gauge'] = gauge
                         item["pu"] = pu
                         item["ewr"] = ewr
                         item["ewr_events"],  = gauge_events[scenario][gauge][pu][ewr]
@@ -206,7 +206,6 @@ def count_events(yearly_events:dict)-> int:
 
     Args:
         yearly_events (dict): ewr yearly events dictionary of lists of lists
-
     Returns:
         int: count of length of all events in the collection of years
     """
@@ -227,7 +226,7 @@ def sum_events(yearly_events:dict)-> int:
     return len(list(chain(*flattened_events)))
 
 
-def process_yearly_events(scenario:str, gauge:str, pu:str, ewr:str, ewr_events: Dict)-> pd.DataFrame:
+def process_yearly_events(scenario:str, Gauge:str, pu:str, ewr:str, ewr_events: Dict)-> pd.DataFrame:
     """process each item for the gauge and return the statistics in a DataFrame
 
     Args:
@@ -246,7 +245,7 @@ def process_yearly_events(scenario:str, gauge:str, pu:str, ewr:str, ewr_events: 
     total_event_days = sum_events(yearly_events)
     average_event_length = total_event_days/total_events if total_events else 0
     row_data['scenario'].append(scenario)
-    row_data['gauge'].append(gauge)
+    row_data['Gauge'].append(Gauge)
     row_data['pu'].append(pu)
     row_data['ewrCode'].append(ewr)
     row_data['totalEvents'].append(total_events)
@@ -271,7 +270,7 @@ def process_ewr_events_stats(events_to_process: List[Dict])-> pd.DataFrame:
         returned_dfs.append(row_data)
     return pd.concat(returned_dfs, ignore_index=True)
 
-def process_all_yearly_events(scenario:str, gauge:str, pu:str, ewr:str, ewr_events: Dict)-> pd.DataFrame():
+def process_all_yearly_events(scenario:str, Gauge:str, pu:str, ewr:str, ewr_events: Dict)-> pd.DataFrame():
     """process each item for the gauge and return all events. Each event is a row with a start and end date
     duration and event length
 
@@ -292,7 +291,7 @@ def process_all_yearly_events(scenario:str, gauge:str, pu:str, ewr:str, ewr_even
             start_date, _ = ev[0]
             end_date, _ = ev[-1]
             df_data["scenario"].append(scenario)
-            df_data["gauge"].append(gauge)
+            df_data['Gauge'].append(Gauge)
             df_data["pu"].append(pu)
             df_data["ewr"].append(ewr)
             df_data["waterYear"].append(year)
@@ -384,9 +383,9 @@ def summarise(input_dict:Dict , events:Dict, parameter_sheet_path:str = None)-> 
     to_process = pu_dfs_to_process(input_dict)
     yearly_ewr_results = process_df_results(to_process)
     
-    # aggregate by "gauge","pu","ewrCode"
+    # aggregate by 'Gauge',"pu","ewrCode"
     final_summary_output = (yearly_ewr_results
-    .groupby(["scenario","gauge","pu","ewrCode"])
+    .groupby(["scenario",'Gauge',"pu","ewrCode"])
     .agg( EventYears = ("eventYears", 'sum'),
           Frequency = ("eventYears", get_frequency),
           AchievementCount = ("numAchieved", 'sum'),
@@ -410,14 +409,14 @@ def summarise(input_dict:Dict , events:Dict, parameter_sheet_path:str = None)-> 
     
     final_summary_output = final_summary_output.merge(ewr_event_stats, 
                                                       'left',
-                                                      left_on=['scenario', 'gauge','pu','ewrCode'], 
-                                                      right_on=['scenario', 'gauge','pu',"ewrCode"])
+                                                      left_on=['scenario', 'Gauge','pu','ewrCode'], 
+                                                      right_on=['scenario', 'Gauge','pu',"ewrCode"])
     # Join Ewr parameter to summary
 
     final_merged = join_ewr_parameters(cols_to_add=['TargetFrequency','MaxInter-event','Multigauge', 'State', 'SWSDLName'],
                                 left_table=final_summary_output,
-                                left_on=['gauge','pu','ewrCode'],
-                                selected_columns=["scenario",'gauge',
+                                left_on=['Gauge','pu','ewrCode'],
+                                selected_columns=["scenario",'Gauge',
                                                     'pu', 'State', 'SWSDLName', 
                                                     'ewrCode',
                                                     'Multigauge',
@@ -459,7 +458,7 @@ def filter_duplicate_start_dates(df: pd.DataFrame) -> pd.DataFrame:
 
     '''
 
-    df.drop_duplicates(subset = ['scenario', 'gauge', 'pu', 'ewr', 'startDate'], keep='last', inplace=True)
+    df.drop_duplicates(subset = ['scenario', 'Gauge', 'pu', 'ewr', 'startDate'], keep='last', inplace=True)
 
     return df
 
@@ -505,9 +504,9 @@ def events_to_interevents(start_date: date, end_date: date, df_events: pd.DataFr
     
     '''
     # Create the unique ID field
-    df_events['ID'] = df_events['scenario']+df_events['gauge']+df_events['pu']+df_events['ewr']
+    df_events['ID'] = df_events['scenario']+df_events['Gauge']+df_events['pu']+df_events['ewr']
     unique_ID = df_events['ID'].unique()
-    all_interEvents = pd.DataFrame(columns = ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'ID', 
+    all_interEvents = pd.DataFrame(columns = ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'ID', 
                                                 'startDate', 'endDate', 'interEventLength'])
 
     for i in unique_ID:
@@ -528,14 +527,14 @@ def events_to_interevents(start_date: date, end_date: date, df_events: pd.DataFr
         if length > 0:
             # Create the new dataframe:
             new_scenario = [contain_values['scenario'].iloc[0]]*length
-            new_gauge = [contain_values['gauge'].iloc[0]]*length
+            new_gauge = [contain_values['Gauge'].iloc[0]]*length
             new_pu = [contain_values['pu'].iloc[0]]*length
             new_state = [contain_values['State'].iloc[0]]*length
             new_sdl = [contain_values['SWSDLName'].iloc[0]]*length
             new_ewr = [contain_values['ewr'].iloc[0]]*length
             new_ID = [contain_values['ID'].iloc[0]]*length
 
-            data = {'scenario': new_scenario, 'gauge': new_gauge, 'pu': new_pu, 'State': new_state, 'SWSDLName': new_sdl, 'ewr': new_ewr, 'ID': new_ID, 'startDate': inter_starts, 'endDate': inter_ends}
+            data = {'scenario': new_scenario, 'Gauge': new_gauge, 'pu': new_pu, 'State': new_state, 'SWSDLName': new_sdl, 'ewr': new_ewr, 'ID': new_ID, 'startDate': inter_starts, 'endDate': inter_ends}
 
             df_subset = pd.DataFrame(data=data)
 
@@ -582,10 +581,10 @@ def filter_successful_events(all_events: pd.DataFrame, ewr_table_path: str = Non
 
     s = 'TEMPORARY_ID_SPLIT'
 
-    all_events['ID'] = all_events['scenario']+s+all_events['gauge']+s+all_events['pu']+s+all_events['ewr']
+    all_events['ID'] = all_events['scenario']+s+all_events['Gauge']+s+all_events['pu']+s+all_events['ewr']
     unique_ID = list(OrderedDict.fromkeys(all_events['ID']))
     EWR_table, bad_EWRs = data_inputs.get_EWR_table(ewr_table_path)
-    all_successfulEvents = pd.DataFrame(columns = ['scenario', 'gauge', 'pu', 'ewr', 'waterYear', 'startDate', 'endDate', 'eventDuration', 'eventLength', 'multigauge' 'ID'])
+    all_successfulEvents = pd.DataFrame(columns = ['scenario', 'Gauge', 'pu', 'ewr', 'waterYear', 'startDate', 'endDate', 'eventDuration', 'eventLength', 'multigauge' 'ID'])
     
     # Filter out unsuccesful events
     # Iterate over the all_events dataframe
@@ -621,8 +620,8 @@ def get_rolling_max_interEvents(df:pd.DataFrame, start_date: date, end_date: dat
 
     s = 'TEMPORARY_ID_SPLIT'
 
-    df['ID'] = df['scenario']+s+df['gauge']+s+df['pu']+s+df['ewr']
-    yearly_df['ID'] = yearly_df['scenario']+s+yearly_df['gauge']+s+yearly_df['pu']+s+yearly_df['ewrCode']
+    df['ID'] = df['scenario']+s+df['Gauge']+s+df['pu']+s+df['ewr']
+    yearly_df['ID'] = yearly_df['scenario']+s+yearly_df['Gauge']+s+yearly_df['pu']+s+yearly_df['ewrCode']
     unique_ID = list(OrderedDict.fromkeys(yearly_df['ID']))
     master_dict = dict()
     unique_years = list(range(min(yearly_df['Year']),max(yearly_df['Year'])+1,1))
@@ -710,7 +709,7 @@ def add_interevent_to_yearly_results(yearly_df: pd.DataFrame, yearly_dict:Dict) 
         if any( cllmm in ewr for cllmm in cllmm_post_processed):
             continue
         scenario = yearly_df.loc[i, 'scenario']
-        gauge = yearly_df.loc[i, 'gauge']
+        gauge = yearly_df.loc[i, 'Gauge']
         pu = yearly_df.loc[i, 'pu']
         year = yearly_df.loc[i, 'Year']
         value_to_add = yearly_dict[scenario][gauge][pu][ewr][year]
@@ -736,7 +735,7 @@ def add_interevent_check_to_yearly_results(yearly_df: pd.DataFrame, ewr_table_pa
 
     # Get EWR characteristics for current EWR
     for i, row in yearly_df.iterrows():
-        gauge = yearly_df.loc[i, 'gauge']
+        gauge = yearly_df.loc[i, 'Gauge']
         pu = yearly_df.loc[i, 'pu']
         ewr = yearly_df.loc[i, 'ewrCode']
 

--- a/readme.md.amltmp
+++ b/readme.md.amltmp
@@ -1,7 +1,7 @@
 [![CI](https://github.com/MDBAuth/EWR_tool/actions/workflows/tox-test.yml/badge.svg)]()
 
 
-### **EWR tool beta 0.0.8 README**
+### **ewr tool beta 0.0.8 README**
 
 **Installation**
 
@@ -15,17 +15,17 @@ pip install py-ewr
 
 **Purpose**
 This tool has two purposes:
-1. Operational: Tracking EWR success at gauges of interest in real time.
-2. Planning: Comparing EWR success between scenarios (i.e. model runs)
+1. Operational: Tracking ewr success at gauges of interest in real time.
+2. Planning: Comparing ewr success between scenarios (i.e. model runs)
 
 **Support**
 For issues relating to the script, a tutorial, or feedback please contact Martin Job at martin.job@mdba.gov.au or Joel Bailey at joel.bailey@mdba.gov.au
 
 **Notes on development of the tool**
-This is the version 0.0.6 of the EWR tool. Testing is still being undertaken.
+This is the version 0.0.6 of the ewr tool. Testing is still being undertaken.
 
 **Disclaimer**
-Every effort has been taken to ensure the EWR database represents the original EWRs from state long term water plans as best as possible, and that the code within this tool has been developed to interpret and analyse these EWRs in an accurate way. However, there may still be unresolved bugs in the database and/or EWR tool. Please report any bugs to the issues tab under this GitHub project so we can investigate further. 
+Every effort has been taken to ensure the ewr database represents the original EWRs from state long term water plans as best as possible, and that the code within this tool has been developed to interpret and analyse these EWRs in an accurate way. However, there may still be unresolved bugs in the database and/or ewr tool. Please report any bugs to the issues tab under this GitHub project so we can investigate further. 
 
 
 **Notes on development of the database**
@@ -40,7 +40,7 @@ NSW:
 Work is currently underway to migrate the EWRs in the remaining Basin catchments.
 
 **Input data**
-- EWR information: This tool accesses the EWRs in the Environmental Assets & Functions Database (EAFD)
+- ewr information: This tool accesses the EWRs in the Environmental Assets & Functions Database (EAFD)
 - Climate data from the AWRA-L model
 - Gauge data from the relevant state websites
 - Scenario data input by the user

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pandas
 requests
 tqdm
 traitlets
-xarray
+xarray==2023.9.0
 netCDF4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def detailed_results(pu_df):
 @pytest.fixture(scope="function")
 def item_to_process(pu_df):
     return { "scenario" : 'observed',
-                         "gauge" : '419001',
+                         'Gauge' : '419001',
                          "pu" : 'Keepit to Boggabri',
                          "pu_df" : pu_df }
 
@@ -43,11 +43,11 @@ def item_to_process(pu_df):
 def items_to_process(pu_df):
 
     return [ { "scenario" : 'observed',
-                "gauge" : '419001',
+                'Gauge' : '419001',
                 "pu" : 'Keepit to Boggabri',
                 "pu_df" : pu_df },
              { "scenario" : 'observed',
-                "gauge" : '419002',
+                'Gauge' : '419002',
                 "pu" : 'Keepit to Boggabri',
                 "pu_df" : pu_df }
            ]
@@ -80,7 +80,7 @@ def yearly_events():
 @pytest.fixture(scope="function")
 def event_item_to_process():
     return  {  "scenario" : 'observed',
-                "gauge" : '419001',
+                'Gauge' : '419001',
                 "pu" : 'Keepit to Boggabri',
                 "ewr": 'CF1_a',
                 "ewr_events" :  {  2010: [],
@@ -98,7 +98,7 @@ def event_item_to_process():
 @pytest.fixture(scope="function")
 def event_items_to_process():
     return  [{  "scenario" : 'observed',
-                "gauge" : '419001',
+                'Gauge' : '419001',
                 "pu" : 'Keepit to Boggabri',
                 "ewr": 'CF1_a',
                 "ewr_events" :  {  2010: [],
@@ -113,7 +113,7 @@ def event_items_to_process():
                                             (date(2020, 12, 5), 0.0),]]}
                                     },
                 {  "scenario" : 'observed',
-                "gauge" : '419002',
+                'Gauge' : '419002',
                 "pu" : 'Keepit to Boggabri',
                 "ewr": 'CF1_a',
                 "ewr_events" : {  2010: [],
@@ -250,7 +250,7 @@ def wp_EWR_table(parameter_sheet):
     wp_flow_level_gauges = ['414203', '414209', '425010', 'A4260501' ]
 
 
-    return parameter_sheet[(parameter_sheet["Gauge"].isin(wp_flow_level_gauges))&(parameter_sheet["Code"].isin(["WP3","WP4","LF2-WP","SF-WP"]))] 
+    return parameter_sheet[(parameter_sheet['Gauge'].isin(wp_flow_level_gauges))&(parameter_sheet["Code"].isin(["WP3","WP4","LF2-WP","SF-WP"]))] 
 
 
 @pytest.fixture(scope="function")
@@ -282,7 +282,7 @@ def PU_df_wp():
 @pytest.fixture(scope="function")
 def interEvent_item_to_process():
     return {'scenario': ['example_scenario']*9,
-            'gauge': ['409025']*6+['410007']*3, 
+            'Gauge': ['409025']*6+['410007']*3, 
             'pu': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
             'State': ['NSW']*9,
             'SWSDLName': ['New South Wales Murray']*6+['Murrumbidgee']*3, 
@@ -297,7 +297,7 @@ def interEvent_item_to_process():
 @pytest.fixture(scope="function")
 def successfulEvent_item_to_process():
     return {'scenario': ['example_scenario']*9,
-            'gauge': ['409025']*6+['410007']*3, 
+            'Gauge': ['409025']*6+['410007']*3, 
             'pu': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
             'ewr': ['VF']*3+['LF2']*3+['SF2']*3,
             'waterYear': ['1901', '1901', '1904']*3, 
@@ -310,7 +310,7 @@ def successfulEvent_item_to_process():
 @pytest.fixture(scope="function")
 def duplicate_event_item_to_process():
     return {'scenario': ['example_scenario']*9,
-            'gauge': ['409025']*6+['410007']*3, 
+            'Gauge': ['409025']*6+['410007']*3, 
             'pu': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
             'ewr': ['VF']*3+['LF2']*3+['SF2']*3,
             'waterYear': ['1901', '1901', '1904']*3, 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def detailed_results(pu_df):
 def item_to_process(pu_df):
     return { "scenario" : 'observed',
                          'Gauge' : '419001',
-                         "pu" : 'Keepit to Boggabri',
+                         "PlanningUnit" : 'Keepit to Boggabri',
                          "pu_df" : pu_df }
 
 @pytest.fixture(scope="function")
@@ -44,11 +44,11 @@ def items_to_process(pu_df):
 
     return [ { "scenario" : 'observed',
                 'Gauge' : '419001',
-                "pu" : 'Keepit to Boggabri',
+                "PlanningUnit" : 'Keepit to Boggabri',
                 "pu_df" : pu_df },
              { "scenario" : 'observed',
                 'Gauge' : '419002',
-                "pu" : 'Keepit to Boggabri',
+                "PlanningUnit" : 'Keepit to Boggabri',
                 "pu_df" : pu_df }
            ]
 
@@ -81,8 +81,8 @@ def yearly_events():
 def event_item_to_process():
     return  {  "scenario" : 'observed',
                 'Gauge' : '419001',
-                "pu" : 'Keepit to Boggabri',
-                "ewr": 'CF1_a',
+                "PlanningUnit" : 'Keepit to Boggabri',
+                "Code": 'CF1_a',
                 "ewr_events" :  {  2010: [],
                                     2011: [],
                                     2012: [],
@@ -99,8 +99,8 @@ def event_item_to_process():
 def event_items_to_process():
     return  [{  "scenario" : 'observed',
                 'Gauge' : '419001',
-                "pu" : 'Keepit to Boggabri',
-                "ewr": 'CF1_a',
+                "PlanningUnit" : 'Keepit to Boggabri',
+                "Code": 'CF1_a',
                 "ewr_events" :  {  2010: [],
                                     2011: [],
                                     2012: [],
@@ -114,8 +114,8 @@ def event_items_to_process():
                                     },
                 {  "scenario" : 'observed',
                 'Gauge' : '419002',
-                "pu" : 'Keepit to Boggabri',
-                "ewr": 'CF1_a',
+                "PlanningUnit" : 'Keepit to Boggabri',
+                "Code": 'CF1_a',
                 "ewr_events" : {  2010: [],
                                     2011: [],
                                     2012: [],
@@ -283,10 +283,10 @@ def PU_df_wp():
 def interEvent_item_to_process():
     return {'scenario': ['example_scenario']*9,
             'Gauge': ['409025']*6+['410007']*3, 
-            'pu': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
+            'PlanningUnit': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
             'State': ['NSW']*9,
             'SWSDLName': ['New South Wales Murray']*6+['Murrumbidgee']*3, 
-            'ewr': ['VF']*3+['LF2']*3+['SF2']*3,
+            'Code': ['VF']*3+['LF2']*3+['SF2']*3,
             'waterYear': ['1901', '1901', '1904']*3, 
             'startDate': [date(1901, 8, 1), date(1901, 12, 1), date(1904, 1, 31), date(1901, 8, 5), date(1901, 12, 1), date(1904, 1, 31), date(1901, 8, 10), date(1901, 12, 6), date(1904, 1, 31)], 
             'endDate': [date(1901, 8, 31), date(1901, 12, 15), date(1904, 3, 31), date(1901, 8, 25), date(1901, 12, 10), date(1904, 2, 15), date(1901, 8, 15), date(1901, 12, 8), date(1904, 2, 5)], 
@@ -298,8 +298,8 @@ def interEvent_item_to_process():
 def successfulEvent_item_to_process():
     return {'scenario': ['example_scenario']*9,
             'Gauge': ['409025']*6+['410007']*3, 
-            'pu': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
-            'ewr': ['VF']*3+['LF2']*3+['SF2']*3,
+            'PlanningUnit': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
+            'Code': ['VF']*3+['LF2']*3+['SF2']*3,
             'waterYear': ['1901', '1901', '1904']*3, 
             'startDate': [date(1901, 8, 1), date(1901, 12, 1), date(1904, 1, 31), date(1901, 8, 5), date(1901, 12, 1), date(1904, 1, 31), date(1901, 8, 10), date(1901, 12, 6), date(1904, 1, 31)], 
             'endDate': [date(1901, 8, 31), date(1901, 12, 2), date(1904, 3, 31), date(1901, 8, 25), date(1901, 12, 9), date(1904, 2, 15), date(1901, 8, 15), date(1901, 12, 8), date(1904, 3, 5)], 
@@ -311,8 +311,8 @@ def successfulEvent_item_to_process():
 def duplicate_event_item_to_process():
     return {'scenario': ['example_scenario']*9,
             'Gauge': ['409025']*6+['410007']*3, 
-            'pu': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
-            'ewr': ['VF']*3+['LF2']*3+['SF2']*3,
+            'PlanningUnit': ['Murray River - Yarrawonga to Barmah']*6+['Upper Yanco Creek']*3, 
+            'Code': ['VF']*3+['LF2']*3+['SF2']*3,
             'waterYear': ['1901', '1901', '1904']*3, 
             'startDate': [date(1901, 8, 1), date(1901, 8, 1), date(1904, 1, 31), date(1901, 8, 5), date(1901, 12, 1), date(1904, 1, 31), date(1901, 8, 10), date(1901, 12, 6), date(1901, 12, 6)], 
             'endDate': [date(1901, 8, 31), date(1901, 12, 2), date(1904, 3, 31), date(1901, 8, 25), date(1901, 12, 9), date(1904, 2, 15), date(1901, 8, 15), date(1901, 12, 8), date(1904, 3, 5)], 
@@ -328,12 +328,12 @@ def ewr_calc_config():
 @pytest.fixture(scope="function")
 def gauge_results():
     return {"scenario":
-            {"A4261002":{"pu":"DataFrame"},
-            "A4260527":{"pu":"DataFrame"},
-            "A4260633":{"pu":"DataFrame"},
-            "A4260634":{"pu":"DataFrame"},
-            "A4260635":{"pu":"DataFrame"},
-            "A4260637":{"pu":"DataFrame"}
+            {"A4261002":{"PlanningUnit":"DataFrame"},
+            "A4260527":{"PlanningUnit":"DataFrame"},
+            "A4260633":{"PlanningUnit":"DataFrame"},
+            "A4260634":{"PlanningUnit":"DataFrame"},
+            "A4260635":{"PlanningUnit":"DataFrame"},
+            "A4260637":{"PlanningUnit":"DataFrame"}
             }
     }
 

--- a/tests/test_data_inputs.py
+++ b/tests/test_data_inputs.py
@@ -15,8 +15,8 @@ BASE_PATH = Path(__file__).resolve().parents[1]
     
 def test_get_multi_gauges():
     '''
-    1. Test for returning planning units and gauges where there are multi gauge EWR requirements
-    2. Test for returning the unique gauge to gauge dictionaries where there are multi gauge EWR requirements
+    1. Test for returning planning units and gauges where there are multi gauge ewr requirements
+    2. Test for returning the unique gauge to gauge dictionaries where there are multi gauge ewr requirements
     '''
     # Test 1
     expected_multi_gauges = {'PU_0000130': {'421090': '421088', '421088': '421090'},
@@ -59,7 +59,7 @@ def test_get_EWR_table():
 
 def test_get_ewr_calc_config():
     '''
-    1. Test for correct return of EWR calculation config
+    1. Test for correct return of ewr calculation config
     assert it returns a dictionary
     '''
 

--- a/tests/test_evaluate_ewr_rest.py
+++ b/tests/test_evaluate_ewr_rest.py
@@ -10,36 +10,36 @@ from contextlib import nullcontext
 
 def test_component_pull():
 	'''
-	1. Test correct value is pulled from EWR dataset
+	1. Test correct value is pulled from ewr dataset
 	'''
 	EWR_table, bad_EWRs = data_inputs.get_EWR_table()
 	gauge = '409025'
-	PU = 'PU_0000253'
-	EWR = 'SF1_P'
+	pu = 'PU_0000253'
+	ewr = 'SF1_P'
 	component = 'Duration'
-	assert  evaluate_EWRs.component_pull(EWR_table, gauge, PU, EWR, component) == 10
+	assert  evaluate_EWRs.component_pull(EWR_table, gauge, pu, ewr, component) == 10
 
 def test_get_EWRs():
 	'''
-	1. Ensure requested parts of EWR are returned
+	1. Ensure requested parts of ewr are returned
 	'''
 	EWR_table, bad_EWRs = data_inputs.get_EWR_table()
-	PU = 'PU_0000283'
+	pu = 'PU_0000283'
 	gauge = '410007'
-	EWR = 'SF1_P'
+	ewr = 'SF1_P'
 	components = ['StartMonth', 'EndMonth']
 
 	expected = {'Gauge': '410007', 'PlanningUnit': 'PU_0000283', 'Code': 'SF1_P', 'start_month': 10, 'end_month':4}
-	assert evaluate_EWRs.get_EWRs(PU, gauge, EWR, EWR_table, components) == expected
+	assert evaluate_EWRs.get_EWRs(pu, gauge, ewr, EWR_table, components) == expected
 
 def test_mask_dates():
 	'''
 	This testing function will also be testing the functions get_month_mask, get_day_month_mask, and get_day_month_mask
-	1. Testing for no filtering (all year round EWR requirement)
+	1. Testing for no filtering (all year round ewr requirement)
 	2. Testing for a month subset
-	3. Testing for water year crossover EWR requirement
-	4. Testing for start day and end day within same month inclusion in the EWR requirement
-	5. Testing for start day and end day within different months inclusion in the EWR requirement:
+	3. Testing for water year crossover ewr requirement
+	4. Testing for start day and end day within same month inclusion in the ewr requirement
+	5. Testing for start day and end day within different months inclusion in the ewr requirement:
 	'''
 	#------------ Dataframe to be passed to all testing functions here ----------#
 
@@ -1476,7 +1476,7 @@ def test_get_event_max_inter_event_achieved(EWR_info,no_events,unique_water_year
 @pytest.mark.parametrize("gauge,ewr,pu,expected_result",[
 	("421004", "CF" , "PU_0000129", nullcontext(False)),
 	("421090", "CF" , "PU_0000130", nullcontext(True)),
-	("11111", "XX" , "DD", pytest.raises(IndexError, match="EWR: gauge=11111, code=XX, pu=DD is not in the parameter sheet")),
+	("11111", "XX" , "DD", pytest.raises(IndexError, match="ewr: gauge=11111, code=XX, pu=DD is not in the parameter sheet")),
 ],)
 def test_is_multigauge(parameter_sheet, gauge, ewr, pu, expected_result):
 	with expected_result as e:
@@ -1486,7 +1486,7 @@ def test_is_multigauge(parameter_sheet, gauge, ewr, pu, expected_result):
 @pytest.mark.parametrize("gauge,ewr,pu,expected_result",[
 	("414203", "VF" , "PU_0000260", nullcontext(True)),
 	("414203", "WP2" , "PU_0000260", nullcontext(True)),
-	("11111", "XX" , "DD", pytest.raises(IndexError, match="EWR: gauge=11111, code=XX, pu=DD is not in the parameter sheet")),
+	("11111", "XX" , "DD", pytest.raises(IndexError, match="ewr: gauge=11111, code=XX, pu=DD is not in the parameter sheet")),
 ],)
 def test_is_weirpool_gauge(parameter_sheet, gauge, ewr, pu, expected_result):
 	with expected_result as e:
@@ -2503,19 +2503,19 @@ def test_lake_calc(EWR_info, levels, expected_all_events, expected_all_no_events
 	# 		assert event == expected_all_events[year][i]
 
 
-@pytest.mark.parametrize('gauge,PU,EWR,component,expected_result',[
+@pytest.mark.parametrize('gauge,pu,ewr,component,expected_result',[
 	('409025','PU_0000253','NestS1','TriggerDay', 15),
 	('409025','PU_0000253','NestS1','TriggerMonth', 9),
 	('414203','PU_0000260','NestS1a','DrawDownRateWeek', 0.03),
 ],)
-def test_component_pull_nest(gauge, PU, EWR, component, expected_result):
+def test_component_pull_nest(gauge, pu, ewr, component, expected_result):
 	'''
 	1. Test pulling TriggerDay
 	2. Test pulling TriggerMonth
 	'''
 	EWR_table, bad_EWRs = data_inputs.get_EWR_table('./unit_testing_files/MURRAY_MDBA_update_nest.csv')
 
-	assert  evaluate_EWRs.component_pull(EWR_table, gauge, PU, EWR, component) == expected_result
+	assert  evaluate_EWRs.component_pull(EWR_table, gauge, pu, ewr, component) == expected_result
 
 @pytest.mark.parametrize("EWR_info,iteration,flow,flow_percent_change,event,all_events,all_no_events,total_event,expected_all_events,expected_event,dates",
 [
@@ -3293,34 +3293,34 @@ def test_get_handle_function(function_name, expected_result):
 	assert result.__name__ == expected_result
 
 @pytest.mark.parametrize("args,function_name,expected_result",[
-	({"PU": "PU" , 
+	({"pu": "pu" , 
 	'gauge': 'gauge', 
-	"EWR": "EWR", 
+	"ewr": "ewr", 
 	"EWR_table": "EWR_table", 
 	"df_F": "df_F", 
 	"df_L": "df_L",
 	"PU_df": "PU_df", 
 	},
 		'ctf_handle', 
-	{"PU": "PU" , 
+	{"pu": "pu" , 
 	'gauge': 'gauge', 
-	"EWR": "EWR", 
+	"ewr": "ewr", 
 	"EWR_table": "EWR_table", 
 	"df_F": "df_F", 
 	"PU_df": "PU_df", 
 	}),
-	({"PU": "PU" , 
+	({"pu": "pu" , 
 	'gauge': 'gauge', 
-	"EWR": "EWR", 
+	"ewr": "ewr", 
 	"EWR_table": "EWR_table", 
 	"df_F": "df_F", 
 	"df_L": "df_L",
 	"PU_df": "PU_df", 
 	},
 		'level_handle', 
-	{"PU": "PU" , 
+	{"pu": "pu" , 
 	'gauge': 'gauge', 
-	"EWR": "EWR", 
+	"ewr": "ewr", 
 	"EWR_table": "EWR_table", 
 	"df_L": "df_L", 
 	"PU_df": "PU_df", 

--- a/tests/test_evaluate_ewr_rest.py
+++ b/tests/test_evaluate_ewr_rest.py
@@ -29,7 +29,7 @@ def test_get_EWRs():
 	EWR = 'SF1_P'
 	components = ['StartMonth', 'EndMonth']
 
-	expected = {'Gauge': '410007', 'planning_unit': 'PU_0000283', 'EWR_code': 'SF1_P', 'start_month': 10, 'end_month':4}
+	expected = {'Gauge': '410007', 'planning_unit': 'PU_0000283', 'Code': 'SF1_P', 'start_month': 10, 'end_month':4}
 	assert evaluate_EWRs.get_EWRs(PU, gauge, EWR, EWR_table, components) == expected
 
 def test_mask_dates():
@@ -3455,7 +3455,7 @@ def test_filter_timing_window_non_std(flows, start, end, flow_date, expected_sta
 	  "low_release_window_end":8,
 	  "high_release_window_start":9, 
 	  "high_release_window_end":12,
-	  'EWR_code': "CLLMM1a",
+	  'Code': "CLLMM1a",
 	  'annual_barrage_flow': 2000000,
 	  'three_years_barrage_flow': 6000000
 	  },
@@ -3484,7 +3484,7 @@ def test_filter_timing_window_non_std(flows, start, end, flow_date, expected_sta
 	  "low_release_window_end":8,
 	  "high_release_window_start":9, 
 	  "high_release_window_end":12,
-	  'EWR_code': "CLLMM1a",
+	  'Code': "CLLMM1a",
 	  'annual_barrage_flow': 2000000,
 	  'three_years_barrage_flow': 6000000
 	  },
@@ -3513,7 +3513,7 @@ def test_filter_timing_window_non_std(flows, start, end, flow_date, expected_sta
 	  "low_release_window_end":8,
 	  "high_release_window_start":9, 
 	  "high_release_window_end":12,
-	  'EWR_code': "CLLMM1b",
+	  'Code': "CLLMM1b",
 	  'annual_barrage_flow': 2000000,
 	  'three_years_barrage_flow': 6000000
 	  },
@@ -3542,7 +3542,7 @@ def test_filter_timing_window_non_std(flows, start, end, flow_date, expected_sta
 	  "low_release_window_end":8,
 	  "high_release_window_start":9, 
 	  "high_release_window_end":12,
-	  'EWR_code': "CLLMM1b",
+	  'Code': "CLLMM1b",
 	  'annual_barrage_flow': 2000000,
 	  'three_years_barrage_flow': 6000000
 	  },
@@ -3593,7 +3593,7 @@ def test_barrage_flow_check(EWR_info,flows,event,all_events,all_no_events,expect
 	  "low_release_window_end":8,
 	  "high_release_window_start":9, 
 	  "high_release_window_end":12,
-	  'EWR_code': "CLLMM1_a",
+	  'Code': "CLLMM1_a",
 	  'annual_barrage_flow': 2000000,
 	  'three_years_barrage_flow': 6000000,
 	  'duration': 1
@@ -3611,7 +3611,7 @@ def test_barrage_flow_check(EWR_info,flows,event,all_events,all_no_events,expect
 	  "low_release_window_end":8,
 	  "high_release_window_start":9, 
 	  "high_release_window_end":12,
-	  'EWR_code': "CLLMM1_b",
+	  'Code': "CLLMM1_b",
 	  'annual_barrage_flow': 2000000,
 	  'three_years_barrage_flow': 6000000,
 	  'duration': 1
@@ -3630,7 +3630,7 @@ def test_barrage_flow_check(EWR_info,flows,event,all_events,all_no_events,expect
 	  "low_release_window_end":8,
 	  "high_release_window_start":9, 
 	  "high_release_window_end":12,
-	  'EWR_code': "CLLMM1_b",
+	  'Code': "CLLMM1_b",
 	  'annual_barrage_flow': 2000000,
 	  'three_years_barrage_flow': 6000000,
 	  'duration': 1
@@ -5369,15 +5369,15 @@ def test_calculate_n_day_moving_average():
 
 @pytest.mark.parametrize("EWR_info, expected_type",[
 	(
-	{ 'EWR_code': "CLLMM1c_P"},
+	{ 'Code': "CLLMM1c_P"},
 	'c'
 	),
 	(
-	{ 'EWR_code': "CLLMM1d"},
+	{ 'Code': "CLLMM1d"},
 	'd'
 	),
 	(
-	{ 'EWR_code': "CLLMM1a_S"},
+	{ 'Code': "CLLMM1a_S"},
 	'a'
 	),
 ])

--- a/tests/test_evaluate_ewr_rest.py
+++ b/tests/test_evaluate_ewr_rest.py
@@ -29,7 +29,7 @@ def test_get_EWRs():
 	EWR = 'SF1_P'
 	components = ['StartMonth', 'EndMonth']
 
-	expected = {'Gauge': '410007', 'planning_unit': 'PU_0000283', 'Code': 'SF1_P', 'start_month': 10, 'end_month':4}
+	expected = {'Gauge': '410007', 'PlanningUnit': 'PU_0000283', 'Code': 'SF1_P', 'start_month': 10, 'end_month':4}
 	assert evaluate_EWRs.get_EWRs(PU, gauge, EWR, EWR_table, components) == expected
 
 def test_mask_dates():

--- a/tests/test_evaluate_ewr_rest.py
+++ b/tests/test_evaluate_ewr_rest.py
@@ -29,7 +29,7 @@ def test_get_EWRs():
 	EWR = 'SF1_P'
 	components = ['StartMonth', 'EndMonth']
 
-	expected = {'gauge': '410007', 'planning_unit': 'PU_0000283', 'EWR_code': 'SF1_P', 'start_month': 10, 'end_month':4}
+	expected = {'Gauge': '410007', 'planning_unit': 'PU_0000283', 'EWR_code': 'SF1_P', 'start_month': 10, 'end_month':4}
 	assert evaluate_EWRs.get_EWRs(PU, gauge, EWR, EWR_table, components) == expected
 
 def test_mask_dates():
@@ -3294,7 +3294,7 @@ def test_get_handle_function(function_name, expected_result):
 
 @pytest.mark.parametrize("args,function_name,expected_result",[
 	({"PU": "PU" , 
-	"gauge": "gauge", 
+	'gauge': 'gauge', 
 	"EWR": "EWR", 
 	"EWR_table": "EWR_table", 
 	"df_F": "df_F", 
@@ -3303,14 +3303,14 @@ def test_get_handle_function(function_name, expected_result):
 	},
 		'ctf_handle', 
 	{"PU": "PU" , 
-	"gauge": "gauge", 
+	'gauge': 'gauge', 
 	"EWR": "EWR", 
 	"EWR_table": "EWR_table", 
 	"df_F": "df_F", 
 	"PU_df": "PU_df", 
 	}),
 	({"PU": "PU" , 
-	"gauge": "gauge", 
+	'gauge': 'gauge', 
 	"EWR": "EWR", 
 	"EWR_table": "EWR_table", 
 	"df_F": "df_F", 
@@ -3319,7 +3319,7 @@ def test_get_handle_function(function_name, expected_result):
 	},
 		'level_handle', 
 	{"PU": "PU" , 
-	"gauge": "gauge", 
+	'gauge': 'gauge', 
 	"EWR": "EWR", 
 	"EWR_table": "EWR_table", 
 	"df_L": "df_L", 

--- a/tests/test_evaluate_ewrs.py
+++ b/tests/test_evaluate_ewrs.py
@@ -12,9 +12,9 @@ def test_ctf_handle():
     1. Ensure all parts of the function generate expected output
     '''
     # set up input data
-    PU = 'PU_0000283'
+    pu = 'PU_0000283'
     gauge = '410007'
-    EWR = 'CF1'
+    ewr = 'CF1'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_F = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),#.to_period(),
                         gauge: [0]*1+[0]*350+[0]*9+[0]*5 + [0]*360+[0]*5 + [0]*10+[0]*345+[0]*1+[0]*9 + [0]*5+[0]*351+[0]*10}
@@ -22,7 +22,7 @@ def test_ctf_handle():
     df_F = df_F.set_index('Date')
     PU_df = pd.DataFrame()
     # Send input data to test function:
-    PU_df, events = evaluate_EWRs.ctf_handle(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.ctf_handle(pu, gauge, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output - PU_df
     data = {'CF1_eventYears': [0,0,0,1], 'CF1_numAchieved': [0,0,0,1], 'CF1_numEvents': [0,0,0,1], 'CF1_numEventsAll': [0,0,0,1], 
       'CF1_maxInterEventDays': [0,0,0,0],  'CF1_maxInterEventDaysAchieved': [1,1,1,1], 'CF1_eventLength': [0.0,0.0,0.0,1461.0], 'CF1_eventLengthAchieved': [0.0,0.0,0.0,1461.0], 
@@ -51,9 +51,9 @@ def test_lowflow_handle():
     1. Ensure all parts of the function generate expected output
     '''
     # Set up input data
-    PU = 'PU_0000283'
+    pu = 'PU_0000283'
     gauge = '410007'
-    EWR = 'BF1_a'
+    ewr = 'BF1_a'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_F = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),#.to_period(),
                         gauge: [0]*1+[249]*350+[0]*9+[0]*5 + [0]*360+[0]*5 + [0]*2+[249]*345+[0]*1+[249]*17 + [0]*5+[249]*351+[249]*10}
@@ -61,7 +61,7 @@ def test_lowflow_handle():
     df_F = df_F.set_index('Date')
     PU_df = pd.DataFrame()
     # Send input data to test function
-    PU_df, events = evaluate_EWRs.lowflow_handle(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.lowflow_handle(pu, gauge, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output data - PU_df, and testing
     data = {'BF1_a_eventYears': [0,0,0,0], 'BF1_a_numAchieved': [0,0,0,0], 'BF1_a_numEvents': [0,0,0,0], 'BF1_a_numEventsAll': [0,0,0,0],
             'BF1_a_maxInterEventDays': [0,0,0,0], 
@@ -91,9 +91,9 @@ def test_flow_handle():
     1. Ensure all parts of the function generate expected output
     '''
     # Setting up input data
-    PU = 'PU_0000283'
+    pu = 'PU_0000283'
     gauge = '410007'
-    EWR = 'SF1_S'
+    ewr = 'SF1_S'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_F = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),#.to_period(),
                         gauge: [0]*1+[250]*350+[450]*10+[0]*4 + 
@@ -105,7 +105,7 @@ def test_flow_handle():
     df_F = df_F.set_index('Date')
     PU_df = pd.DataFrame()
     # Send input data to test function
-    PU_df, events = evaluate_EWRs.flow_handle(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.flow_handle(pu, gauge, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output - PU_df - and testing
     data = {'SF1_S_eventYears': {2012: 0, 2013: 0, 2014: 0, 2015: 1}, 
             'SF1_S_numAchieved': {2012: 0, 2013: 0, 2014: 0, 2015: 1}, 
@@ -144,13 +144,13 @@ def test_cumulative_handle():
     1. Ensure all parts of the function generate expected output
     '''
     # Set up input data
-    PU = 'PU_0000040'
+    pu = 'PU_0000040'
     gauge = '418068'
     gauge_flows = ([0]*1+[0]*350+[10000]*1+[3000]*4 +[0]*9 + 
                    [0]*360+[450]*3+[19000]*1+[1000]*1 + 
                    [450]*5+[250]*345+[0]*1+[0]*13+[5000]*1 + 
                    [5000]*4+[450]*10+[0]*2+[450]*10+[250]*330+[450]*10)
-    EWR = 'OB3_S'
+    ewr = 'OB3_S'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_F = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),
                         gauge: gauge_flows}
@@ -158,7 +158,7 @@ def test_cumulative_handle():
     df_F = df_F.set_index('Date')
     PU_df = pd.DataFrame()
     # Send input data to test function
-    PU_df, events = evaluate_EWRs.cumulative_handle(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.cumulative_handle(pu, gauge, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output - PU_df - and testing
     data = {'OB3_S_eventYears': [1,0,0,0], 'OB3_S_numAchieved': [1,0,0,0], 'OB3_S_numEvents': [1,0,0,0], 'OB3_S_numEventsAll': [1,0,0,0], 
             'OB3_S_maxInterEventDays': [0, 0, 0, 0], 
@@ -206,9 +206,9 @@ def test_cumulative_handle():
 ])
 def test_cumulative_handle_qld(qld_parameter_sheet,expected_events, expected_PU_df_data):
     # Set up input data
-    PU = 'PU_0000991'
+    pu = 'PU_0000991'
     gauge = '422016'
-    EWR = 'BBR2'
+    ewr = 'BBR2'
 
     EWR_table = qld_parameter_sheet
 
@@ -227,7 +227,7 @@ def test_cumulative_handle_qld(qld_parameter_sheet,expected_events, expected_PU_
     
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.cumulative_handle_qld(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.cumulative_handle_qld(pu, gauge, ewr, EWR_table, df_F, PU_df)
 
     expected_events = tuple([expected_events])
     for index, _ in enumerate(events):
@@ -241,9 +241,9 @@ def test_level_handle():
     1. Ensure all parts of the function generate expected output
     '''
     # Set up input data
-    PU = 'PU_0000266'
+    pu = 'PU_0000266'
     gauge = '425022'
-    EWR = 'LLLF'
+    ewr = 'LLLF'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_L = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),#.to_period(),
                         gauge: [0]*1+[0]*260+[56]*90+[0]*1+[0]*4+[0]*9 + 
@@ -254,7 +254,7 @@ def test_level_handle():
     df_L = df_L.set_index('Date')
     PU_df = pd.DataFrame()
     # Send input data to test function
-    PU_df, events = evaluate_EWRs.level_handle(PU, gauge, EWR, EWR_table, df_L, PU_df)
+    PU_df, events = evaluate_EWRs.level_handle(pu, gauge, ewr, EWR_table, df_L, PU_df)
     # Setting up expected output - PU_df and test
     data = {'LLLF_eventYears': [1,0,0,1], 'LLLF_numAchieved': [1,0,0,1], 'LLLF_numEvents': [1,0,0,1], 'LLLF_numEventsAll': [1,0,0,1], 
             'LLLF_maxInterEventDays': [0, 0, 0, 0], 
@@ -284,9 +284,9 @@ def test_nest_handle():
     1. Ensure all parts of the function generate expected output
     '''
     # Set up input data
-    PU = 'PU_0000253'
+    pu = 'PU_0000253'
     gauge = '409025'
-    EWR = 'NestS1'
+    ewr = 'NestS1'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     # input data up df_L:
     # flows declining at acceptable rate:
@@ -319,7 +319,7 @@ def test_nest_handle():
     df_L = pd.DataFrame()
     PU_df = pd.DataFrame()
     # Pass input data to test function:
-    PU_df, events = evaluate_EWRs.nest_handle(PU, gauge, EWR, EWR_table, df_F, df_L, PU_df)
+    PU_df, events = evaluate_EWRs.nest_handle(pu, gauge, ewr, EWR_table, df_F, df_L, PU_df)
     # Setting up expected output - PU_df - and testing
     data = {'NestS1_eventYears': [1,0,0,0], 'NestS1_numAchieved': [1,0,0,0], 'NestS1_numEvents': [1,0,0,0], 'NestS1_numEventsAll': [1,2,2,2], 
             'NestS1_maxInterEventDays': [0, 0, 0, 0], 
@@ -366,10 +366,10 @@ def test_flow_handle_multi():
     1. Ensure all parts of the function generate expected output
     '''
     # Set up input data
-    PU = 'PU_0000130'
+    pu = 'PU_0000130'
     gauge1 = '421090'
     gauge2 = '421088'
-    EWR = 'LF1'
+    ewr = 'LF1'
     gauge1_flows = ([0]*76+[1250]*5+[0]*229+[0]*55 + [0]*76+[0]*55+[0]*231+[1250]*3 + [1250]*3+[0]*76+[0]*50+[1250]*5+[0]*231 + [0]*77+[1250]*5+[0]*229+[0]*55)
     gauge2_flows = ([0]*76+[1250]*5+[0]*229+[0]*55 + [0]*76+[0]*55+[0]*231+[1250]*3 + [1250]*3+[0]*76+[0]*50+[1250]*5+[0]*231 + [0]*76+[1250]*5+[0]*230+[0]*55)
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
@@ -382,7 +382,7 @@ def test_flow_handle_multi():
     df_L = pd.DataFrame()
     PU_df = pd.DataFrame()
     # Send input data to test function
-    PU_df, events = evaluate_EWRs.flow_handle_multi(PU, gauge1, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.flow_handle_multi(pu, gauge1, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output - PU_df - and testing
     data = {'LF1_eventYears': [1,0,1,0], 'LF1_numAchieved': [1,0,1,0], 'LF1_numEvents': [1,0,1,0], 'LF1_numEventsAll': [1, 1, 2, 1], 
             'LF1_maxInterEventDays': [0, 0, 0, 0], 
@@ -413,10 +413,10 @@ def test_lowflow_handle_multi():
     1. Ensure all parts of the function generate expected output
     '''
     # Input data
-    PU = 'PU_0000130'
+    pu = 'PU_0000130'
     gauge1 = '421090'
     gauge2 = '421088'
-    EWR = 'BF1_a'
+    ewr = 'BF1_a'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_F = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),#.to_period(),
                         gauge1: [40]*76+[1250]*5+[40]*229+[40]*15+[0]*40 + [40]*3+[0]*76+[0]*50+[0]*5+[0]*231 + [40]*75+[0]*50+[40]*230+[40]*10 + [0]*77+[40]*5+[0]*229+[40]*55,
@@ -427,7 +427,7 @@ def test_lowflow_handle_multi():
     df_L = pd.DataFrame()
     PU_df = pd.DataFrame()
     # Pass input data to test function
-    PU_df, events = evaluate_EWRs.lowflow_handle_multi(PU, gauge1, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.lowflow_handle_multi(pu, gauge1, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output - PU_df - and testing
     data = {'BF1_a_eventYears': [0,0,0,0], 'BF1_a_numAchieved': [0,0,0,0], 'BF1_a_numEvents': [0,0,0,0], 'BF1_a_numEventsAll': [1,0,0,0], 
             'BF1_a_maxInterEventDays': [0, 0, 0, 0], 
@@ -455,10 +455,10 @@ def test_ctf_handle_multi():
     1. Ensure all parts of the function generate expected output
     '''
     # Set up the input data
-    PU = 'PU_0000130'
+    pu = 'PU_0000130'
     gauge1 = '421090'
     gauge2 = '421088'
-    EWR = 'CF'
+    ewr = 'CF'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_F = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),#.to_period(),
                         gauge1: [0]*1+[2]*350+[0]*9+[0]*5 + [2]*360+[0]*5 + [0]*10+[2]*345+[0]*1+[2]*9 + [0]*5+[0]*351+[0]*10,
@@ -469,7 +469,7 @@ def test_ctf_handle_multi():
     df_L = pd.DataFrame()
     PU_df = pd.DataFrame()
     # Pass input data to the test function
-    PU_df, events = evaluate_EWRs.ctf_handle_multi(PU, gauge1, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.ctf_handle_multi(pu, gauge1, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output - PU_df - and testing
     data = {'CF_eventYears': [1,0,1,1], 'CF_numAchieved': [2,0,2,1], 'CF_numEvents': [2,0,2,1], 'CF_numEventsAll': [2,0,2,1],
             'CF_maxInterEventDays': [0, 0, 0, 0], 
@@ -501,7 +501,7 @@ def test_cumulative_handle_multi():
     1. Ensure all parts of the function generate expected output
     '''
     # Set up input data
-    PU = 'PU_0000132'
+    pu = 'PU_0000132'
     gauge1 = '421090'
     gauge2 = '421088'
     gauge1_flows = ([0]*1+[0]*260+[334]*90+[0]*5+[0]*9 + 
@@ -512,7 +512,7 @@ def test_cumulative_handle_multi():
                     [0]*310+[0]*3+[0]*1+[0]*1+[500]*50 + 
                     [500]*40+[0]*310+[0]*1+[0]*13+[0]*1 + 
                     [5000]*4+[500]*90+[500]*90+[450]*10+[0]*2+ [450]*10+[250]*150+[450]*10)
-    EWR = 'OB-WS1_S'
+    ewr = 'OB-WS1_S'
     EWR_table, bad_EWRs = data_inputs.get_EWR_table()
     data_for_df_F = {'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),
                         gauge1: gauge1_flows,
@@ -523,7 +523,7 @@ def test_cumulative_handle_multi():
     df_L = pd.DataFrame()
     PU_df = pd.DataFrame()
     # Pass input data to test function
-    PU_df, events = evaluate_EWRs.cumulative_handle_multi(PU, gauge1, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.cumulative_handle_multi(pu, gauge1, ewr, EWR_table, df_F, PU_df)
     # Setting up expected output - PU_df - and testing
     data = {'OB-WS1_S_eventYears': [1,0,0,1], 'OB-WS1_S_numAchieved': [1,0,0,1], 'OB-WS1_S_numEvents': [1,0,0,1], 'OB-WS1_S_numEventsAll': [1,0,0,1],
             'OB-WS1_S_maxInterEventDays': [0, 0, 0, 0],
@@ -832,7 +832,7 @@ def test_merge_weirpool_with_freshes(PU_df_wp, wp_freshes, freshes_eventYears, w
     assert expeted_pu_df.shape[0] == PU_df_wp.shape[0]
 
 
-@pytest.mark.parametrize("data_for_df_F,EWR,main_gauge,expected_events,pu_df_data", [
+@pytest.mark.parametrize("data_for_df_F,ewr,main_gauge,expected_events,pu_df_data", [
     ({'Date': pd.date_range(start= datetime.strptime('2012-07-01', '%Y-%m-%d'), end = datetime.strptime('2016-06-30', '%Y-%m-%d')),#.to_period(),
                         'A4261002': (
                                [5000]*62 + [16500]*122 + [5000]*181 + 
@@ -877,10 +877,10 @@ def test_merge_weirpool_with_freshes(PU_df_wp, wp_freshes, freshes_eventYears, w
                             'CLLMM1b_missingDays': [0,0,0,0], 'CLLMM1b_totalPossibleDays': [365,365,365,366]}
                         ),
 ])
-def test_barrage_flow_handle(data_for_df_F, EWR, main_gauge, expected_events, pu_df_data, sa_parameter_sheet):
+def test_barrage_flow_handle(data_for_df_F, ewr, main_gauge, expected_events, pu_df_data, sa_parameter_sheet):
 
     # Set up input data
-    PU = 'PU_0000029'
+    pu = 'PU_0000029'
 
     EWR_table = sa_parameter_sheet
 	 
@@ -890,7 +890,7 @@ def test_barrage_flow_handle(data_for_df_F, EWR, main_gauge, expected_events, pu
     PU_df = pd.DataFrame()
     # Pass input data to test function:
 
-    PU_df, events = evaluate_EWRs.barrage_flow_handle(PU, main_gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.barrage_flow_handle(pu, main_gauge, ewr, EWR_table, df_F, PU_df)
     
     # Setting up expected output - PU_df - and testing
     index = pd.Index([2012, 2013, 2014, 2015])
@@ -933,10 +933,10 @@ def test_barrage_flow_handle(data_for_df_F, EWR, main_gauge, expected_events, pu
 ])
 def test_barrage_level_handle(sa_parameter_sheet, expected_events, expected_PU_df_data):
     # Set up input data
-    PU = 'PU_0000029'
+    pu = 'PU_0000029'
     gauge = 'A4260527'
     barrage_gauges =  ['A4260527','A4261133', 'A4260524', 'A4260574', 'A4260575']
-    EWR = 'CLLMM1c_P'
+    ewr = 'CLLMM1c_P'
     gauge_levels = (  [.55]*66 + [.8]*5 + [.6]*115 + [.55]*179 + 
                             [0]*365 + 
                             [0]*365 + 
@@ -954,7 +954,7 @@ def test_barrage_level_handle(sa_parameter_sheet, expected_events, expected_PU_d
     PU_df = pd.DataFrame()
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.barrage_level_handle(PU, gauge, EWR, EWR_table, df_L, PU_df)
+    PU_df, events = evaluate_EWRs.barrage_level_handle(pu, gauge, ewr, EWR_table, df_L, PU_df)
 
     assert PU_df.to_dict() == expected_PU_df_data
     
@@ -992,9 +992,9 @@ def test_barrage_level_handle(sa_parameter_sheet, expected_events, expected_PU_d
 ])
 def test_flow_handle_sa(sa_parameter_sheet, expected_events, expected_PU_df_data):
      # Set up input data
-    PU = 'PU_0000027'
+    pu = 'PU_0000027'
     gauge = 'A4261001'
-    EWR = 'IC1_P'
+    ewr = 'IC1_P'
 
     EWR_table = sa_parameter_sheet
 
@@ -1014,7 +1014,7 @@ def test_flow_handle_sa(sa_parameter_sheet, expected_events, expected_PU_df_data
     
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.flow_handle_sa(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.flow_handle_sa(pu, gauge, ewr, EWR_table, df_F, PU_df)
 
     assert PU_df.to_dict() == expected_PU_df_data
     
@@ -1054,9 +1054,9 @@ def test_flow_handle_sa(sa_parameter_sheet, expected_events, expected_PU_df_data
 ])
 def test_flow_handle_check_ctf(qld_parameter_sheet, expected_events, expected_PU_df_data):
      # Set up input data
-    PU = 'PU_0000991'
+    pu = 'PU_0000991'
     gauge = '422015'
-    EWR = 'FD1'
+    ewr = 'FD1'
 
     EWR_table = qld_parameter_sheet
 
@@ -1076,7 +1076,7 @@ def test_flow_handle_check_ctf(qld_parameter_sheet, expected_events, expected_PU
     
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.flow_handle_check_ctf(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.flow_handle_check_ctf(pu, gauge, ewr, EWR_table, df_F, PU_df)
 
     assert PU_df.to_dict() == expected_PU_df_data
 
@@ -1113,9 +1113,9 @@ def test_flow_handle_check_ctf(qld_parameter_sheet, expected_events, expected_PU
 ])
 def test_cumulative_handle_bbr(qld_parameter_sheet, expected_events, expected_PU_df_data):
      # Set up input data
-    PU = 'PU_0000991'
+    pu = 'PU_0000991'
     gauge = '422016'
-    EWR = 'BBR1_a'
+    ewr = 'BBR1_a'
 
     EWR_table = qld_parameter_sheet
 
@@ -1145,7 +1145,7 @@ def test_cumulative_handle_bbr(qld_parameter_sheet, expected_events, expected_PU
     
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.cumulative_handle_bbr(PU, gauge, EWR, EWR_table, df_F, df_L, PU_df)
+    PU_df, events = evaluate_EWRs.cumulative_handle_bbr(pu, gauge, ewr, EWR_table, df_F, df_L, PU_df)
 
     assert PU_df.to_dict() == expected_PU_df_data
 
@@ -1238,9 +1238,9 @@ def test_get_achievements_connecting_events(event_years, expected_results):
 ])
 def test_water_stability_handle(qld_parameter_sheet, expected_events, expected_PU_df_data):
      # Set up input data
-    PU = 'PU_0000999'
+    pu = 'PU_0000999'
     gauge = '416011'
-    EWR = 'FrW2'
+    ewr = 'FrW2'
 
     EWR_table = qld_parameter_sheet
 
@@ -1266,7 +1266,7 @@ def test_water_stability_handle(qld_parameter_sheet, expected_events, expected_P
     
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.water_stability_handle(PU, gauge, EWR, EWR_table, df_F, df_L, PU_df)
+    PU_df, events = evaluate_EWRs.water_stability_handle(pu, gauge, ewr, EWR_table, df_F, df_L, PU_df)
 
     assert PU_df.to_dict() == expected_PU_df_data
 
@@ -1305,9 +1305,9 @@ def test_water_stability_handle(qld_parameter_sheet, expected_events, expected_P
 ])
 def test_water_stability_level_handle(qld_parameter_sheet, expected_events, expected_PU_df_data):
      # Set up input data
-    PU = 'PU_0000991'
+    pu = 'PU_0000991'
     gauge = '422015'
-    EWR = 'FrL2'
+    ewr = 'FrL2'
 
     EWR_table = qld_parameter_sheet
 
@@ -1324,7 +1324,7 @@ def test_water_stability_level_handle(qld_parameter_sheet, expected_events, expe
     
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.water_stability_level_handle(PU, gauge, EWR, EWR_table, df_L, PU_df)
+    PU_df, events = evaluate_EWRs.water_stability_level_handle(pu, gauge, ewr, EWR_table, df_L, PU_df)
 
     assert PU_df.to_dict() == expected_PU_df_data
 
@@ -1362,9 +1362,9 @@ def test_water_stability_level_handle(qld_parameter_sheet, expected_events, expe
 ])
 def test_flow_handle_anytime(qld_parameter_sheet, expected_events, expected_PU_df_data):
      # Set up input data
-    PU = 'PU_0000999'
+    pu = 'PU_0000999'
     gauge = '416011'
-    EWR = 'FD1'
+    ewr = 'FD1'
 
     EWR_table = qld_parameter_sheet
 
@@ -1383,7 +1383,7 @@ def test_flow_handle_anytime(qld_parameter_sheet, expected_events, expected_PU_d
     
     # Pass input data to test function:
     
-    PU_df, events = evaluate_EWRs.flow_handle_anytime(PU, gauge, EWR, EWR_table, df_F, PU_df)
+    PU_df, events = evaluate_EWRs.flow_handle_anytime(pu, gauge, ewr, EWR_table, df_F, PU_df)
 
     assert PU_df.to_dict() == expected_PU_df_data
 

--- a/tests/test_evaluate_ewrs.py
+++ b/tests/test_evaluate_ewrs.py
@@ -769,7 +769,7 @@ def test_check_weekly_drawdown(levels, EWR_info, iteration, event_length, expect
     assert result == expected_result
 
 
-# @pytest.mark.parametrize("gauge",[
+# @pytest.mark.parametrize('Gauge',[
 #     ("425010"),
 # ],)
 # def test_calc_sorter_wp(wp_df_F_df_L, wp_EWR_table, ewr_calc_config, gauge):

--- a/tests/test_observed_handling.py
+++ b/tests/test_observed_handling.py
@@ -127,7 +127,7 @@ def test_get_ewr_results(observed_handler_instance):
     ewr_results = observed_handler_instance.get_ewr_results()
     assert type(ewr_results) == pd.DataFrame
     assert ewr_results.shape == (24, 21)
-    assert ewr_results.columns.to_list() == ['Scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'EwrCode', 'Multigauge','EventYears',
+    assert ewr_results.columns.to_list() == ['Scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'Multigauge','EventYears',
        'Frequency', 'TargetFrequency', 'AchievementCount',
        'AchievementPerYear', 'EventCount', 'EventCountAll', 'EventsPerYear', 'EventsPerYearAll',
        'AverageEventLength', 'ThresholdDays',

--- a/tests/test_observed_handling.py
+++ b/tests/test_observed_handling.py
@@ -109,7 +109,7 @@ def test_get_all_events(observed_handler_instance):
     all_events = observed_handler_instance.get_all_events()
     assert type(all_events) == pd.DataFrame
     assert all_events.shape == (76, 12)
-    assert all_events.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+    assert all_events.columns.to_list() == ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                      'eventDuration', 'eventLength', 'Multigauge']
 
 def test_get_yearly_ewr_results(observed_handler_instance):
@@ -120,7 +120,7 @@ def test_get_yearly_ewr_results(observed_handler_instance):
     assert yearly_results.columns.to_list() == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
        'eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved','maxEventDays', 'maxRollingEvents', 'maxRollingAchievement','missingDays',
-       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 'rollingMaxInterEvent', 'rollingMaxInterEventAchieved']
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Multigauge', 'rollingMaxInterEvent', 'rollingMaxInterEventAchieved']
 
 def test_get_ewr_results(observed_handler_instance):
 

--- a/tests/test_observed_handling.py
+++ b/tests/test_observed_handling.py
@@ -109,7 +109,7 @@ def test_get_all_events(observed_handler_instance):
     all_events = observed_handler_instance.get_all_events()
     assert type(all_events) == pd.DataFrame
     assert all_events.shape == (76, 12)
-    assert all_events.columns.to_list() == ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+    assert all_events.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                      'eventDuration', 'eventLength', 'Multigauge']
 
 def test_get_yearly_ewr_results(observed_handler_instance):
@@ -120,7 +120,7 @@ def test_get_yearly_ewr_results(observed_handler_instance):
     assert yearly_results.columns.to_list() == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
        'eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved','maxEventDays', 'maxRollingEvents', 'maxRollingAchievement','missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 'rollingMaxInterEvent', 'rollingMaxInterEventAchieved']
+       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 'rollingMaxInterEvent', 'rollingMaxInterEventAchieved']
 
 def test_get_ewr_results(observed_handler_instance):
 

--- a/tests/test_observed_handling.py
+++ b/tests/test_observed_handling.py
@@ -120,7 +120,7 @@ def test_get_yearly_ewr_results(observed_handler_instance):
     assert yearly_results.columns.to_list() == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
        'eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved','maxEventDays', 'maxRollingEvents', 'maxRollingAchievement','missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 'rollingMaxInterEvent', 'rollingMaxInterEventAchieved']
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 'rollingMaxInterEvent', 'rollingMaxInterEventAchieved']
 
 def test_get_ewr_results(observed_handler_instance):
 

--- a/tests/test_scenario_handling.py
+++ b/tests/test_scenario_handling.py
@@ -548,7 +548,7 @@ def test_get_all_events(scenario_handler_instance):
     all_events = scenario_handler_instance.get_all_events()
     assert type(all_events) == pd.DataFrame
     assert all_events.shape == (26, 12)
-    assert all_events.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+    assert all_events.columns.to_list() == ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'waterYear', 'startDate', 'endDate',
                                      'eventDuration', 'eventLength', 'Multigauge']
         
 def test_get_all_interEvents(scenario_handler_instance):
@@ -556,14 +556,14 @@ def test_get_all_interEvents(scenario_handler_instance):
     all_interEvents = scenario_handler_instance.get_all_interEvents()
     assert type(all_interEvents) == pd.DataFrame
     assert all_interEvents.shape == (26, 9)
-    assert all_interEvents.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'startDate', 'endDate', 'interEventLength']
+    assert all_interEvents.columns.to_list() == ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'startDate', 'endDate', 'interEventLength']
 
 def test_get_all_successful_events(scenario_handler_instance):
 
     all_successful_events = scenario_handler_instance.get_all_successful_events()
     assert type(all_successful_events) == pd.DataFrame
     assert all_successful_events.shape == (24, 12)
-    assert all_successful_events.columns.to_list() == ['scenario', 'Gauge', 'pu', 'ewr', 'waterYear', 'startDate', 'endDate',
+    assert all_successful_events.columns.to_list() == ['scenario', 'Gauge', 'PlanningUnit', 'Code', 'waterYear', 'startDate', 'endDate',
                                                        'eventDuration', 'eventLength', 'State', 'SWSDLName', 'Multigauge']
 
 def test_get_all_successful_interEvents(scenario_handler_instance):
@@ -571,7 +571,7 @@ def test_get_all_successful_interEvents(scenario_handler_instance):
     all_successful_interEvents = scenario_handler_instance.get_all_successful_interEvents()
     assert type(all_successful_interEvents) == pd.DataFrame
     assert all_successful_interEvents.shape == (24, 9)
-    assert all_successful_interEvents.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'startDate', 'endDate', 'interEventLength']
+    assert all_successful_interEvents.columns.to_list() == ['scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'startDate', 'endDate', 'interEventLength']
 
 def test_get_yearly_ewr_results(scenario_handler_instance):
 
@@ -582,7 +582,7 @@ def test_get_yearly_ewr_results(scenario_handler_instance):
     assert yearly_results.columns.to_list() == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
         'eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved','maxEventDays', 'maxRollingEvents', 'maxRollingAchievement', 'missingDays',
-       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Multigauge', 
        'rollingMaxInterEvent', 'rollingMaxInterEventAchieved'] 
 
 def test_get_ewr_results(scenario_handler_instance):

--- a/tests/test_scenario_handling.py
+++ b/tests/test_scenario_handling.py
@@ -582,7 +582,7 @@ def test_get_yearly_ewr_results(scenario_handler_instance):
     assert yearly_results.columns.to_list() == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
         'eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved','maxEventDays', 'maxRollingEvents', 'maxRollingAchievement', 'missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 
        'rollingMaxInterEvent', 'rollingMaxInterEventAchieved'] 
 
 def test_get_ewr_results(scenario_handler_instance):

--- a/tests/test_scenario_handling.py
+++ b/tests/test_scenario_handling.py
@@ -590,7 +590,7 @@ def test_get_ewr_results(scenario_handler_instance):
     ewr_results = scenario_handler_instance.get_ewr_results()
     assert type(ewr_results) == pd.DataFrame
     assert ewr_results.shape == (21, 21)
-    assert ewr_results.columns.to_list() == ['Scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'EwrCode', 'Multigauge','EventYears',
+    assert ewr_results.columns.to_list() == ['Scenario', 'Gauge', 'PlanningUnit', 'State', 'SWSDLName', 'Code', 'Multigauge','EventYears',
        'Frequency', 'TargetFrequency', 'AchievementCount',
        'AchievementPerYear', 'EventCount', 'EventCountAll', 'EventsPerYear', 'EventsPerYearAll',
        'AverageEventLength', 'ThresholdDays', #'InterEventExceedingCount',

--- a/tests/test_scenario_handling.py
+++ b/tests/test_scenario_handling.py
@@ -548,7 +548,7 @@ def test_get_all_events(scenario_handler_instance):
     all_events = scenario_handler_instance.get_all_events()
     assert type(all_events) == pd.DataFrame
     assert all_events.shape == (26, 12)
-    assert all_events.columns.to_list() == ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
+    assert all_events.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'waterYear', 'startDate', 'endDate',
                                      'eventDuration', 'eventLength', 'Multigauge']
         
 def test_get_all_interEvents(scenario_handler_instance):
@@ -556,14 +556,14 @@ def test_get_all_interEvents(scenario_handler_instance):
     all_interEvents = scenario_handler_instance.get_all_interEvents()
     assert type(all_interEvents) == pd.DataFrame
     assert all_interEvents.shape == (26, 9)
-    assert all_interEvents.columns.to_list() == ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'startDate', 'endDate', 'interEventLength']
+    assert all_interEvents.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'startDate', 'endDate', 'interEventLength']
 
 def test_get_all_successful_events(scenario_handler_instance):
 
     all_successful_events = scenario_handler_instance.get_all_successful_events()
     assert type(all_successful_events) == pd.DataFrame
     assert all_successful_events.shape == (24, 12)
-    assert all_successful_events.columns.to_list() == ['scenario', 'gauge', 'pu', 'ewr', 'waterYear', 'startDate', 'endDate',
+    assert all_successful_events.columns.to_list() == ['scenario', 'Gauge', 'pu', 'ewr', 'waterYear', 'startDate', 'endDate',
                                                        'eventDuration', 'eventLength', 'State', 'SWSDLName', 'Multigauge']
 
 def test_get_all_successful_interEvents(scenario_handler_instance):
@@ -571,7 +571,7 @@ def test_get_all_successful_interEvents(scenario_handler_instance):
     all_successful_interEvents = scenario_handler_instance.get_all_successful_interEvents()
     assert type(all_successful_interEvents) == pd.DataFrame
     assert all_successful_interEvents.shape == (24, 9)
-    assert all_successful_interEvents.columns.to_list() == ['scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'startDate', 'endDate', 'interEventLength']
+    assert all_successful_interEvents.columns.to_list() == ['scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'ewr', 'startDate', 'endDate', 'interEventLength']
 
 def test_get_yearly_ewr_results(scenario_handler_instance):
 
@@ -582,7 +582,7 @@ def test_get_yearly_ewr_results(scenario_handler_instance):
     assert yearly_results.columns.to_list() == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll',
         'eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved','maxEventDays', 'maxRollingEvents', 'maxRollingAchievement', 'missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 
+       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu', 'State', 'SWSDLName', 'Multigauge', 
        'rollingMaxInterEvent', 'rollingMaxInterEventAchieved'] 
 
 def test_get_ewr_results(scenario_handler_instance):

--- a/tests/test_summarise_results.py
+++ b/tests/test_summarise_results.py
@@ -64,7 +64,7 @@ def test_process_df(item_to_process):
     columns = result.columns.to_list()
     assert columns == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll','eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved', "rollingMaxInterEventAchieved", 'missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu']
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu']
     assert result.shape == (2, 16)
 
 def test_process_df_results(items_to_process):
@@ -72,7 +72,7 @@ def test_process_df_results(items_to_process):
     columns = result.columns.to_list()
     assert columns == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll','eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved', "rollingMaxInterEventAchieved", 'missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu']
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu']
     assert result.shape == (4, 16)
 
 def test_get_events_to_process(gauge_events):
@@ -112,7 +112,7 @@ def test_process_yearly_events(event_item_to_process):
     assert result.to_dict() == {'scenario': {0: 'observed'},
                                             'Gauge': {0: '419001'},
                                             'pu': {0: 'Keepit to Boggabri'},
-                                            'ewrCode': {0: 'CF1_a'},
+                                            'Code': {0: 'CF1_a'},
                                             'totalEvents': {0: 1},
                                             'totalEventDays': {0: 6},
                                             'averageEventLength': {0: 6.0}}
@@ -124,7 +124,7 @@ def test_process_ewr_events_stats(event_items_to_process):
     assert result.to_dict() == {'scenario': {0: 'observed', 1: 'observed'},
                                 'Gauge': {0: '419001', 1: '419002'},
                                 'pu': {0: 'Keepit to Boggabri', 1: 'Keepit to Boggabri'},
-                                'ewrCode': {0: 'CF1_a', 1: 'CF1_a'},
+                                'Code': {0: 'CF1_a', 1: 'CF1_a'},
                                 'totalEvents': {0: 1, 1: 1},
                                 'totalEventDays': {0: 6, 1: 6},
                                 'averageEventLength': {0: 6.0, 1: 6.0}}

--- a/tests/test_summarise_results.py
+++ b/tests/test_summarise_results.py
@@ -51,11 +51,11 @@ def test_get_ewrs(pu_df):
 def test_pu_dfs_to_process(detailed_results, pu_df):
     result = summarise_results.pu_dfs_to_process(detailed_results)
     assert result == [{ "scenario" : 'observed',
-                         "gauge" : '419001',
+                         'Gauge' : '419001',
                          "pu" : 'Keepit to Boggabri',
                          "pu_df" : pu_df },
                          { "scenario" : 'observed',
-                         "gauge" : '419002',
+                         'Gauge' : '419002',
                          "pu" : 'Keepit to Boggabri',
                          "pu_df" : pu_df }]
 
@@ -64,7 +64,7 @@ def test_process_df(item_to_process):
     columns = result.columns.to_list()
     assert columns == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll','eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved', "rollingMaxInterEventAchieved", 'missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'gauge', 'pu']
+       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu']
     assert result.shape == (2, 16)
 
 def test_process_df_results(items_to_process):
@@ -72,13 +72,13 @@ def test_process_df_results(items_to_process):
     columns = result.columns.to_list()
     assert columns == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll','eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved', "rollingMaxInterEventAchieved", 'missingDays',
-       'totalPossibleDays', 'ewrCode', 'scenario', 'gauge', 'pu']
+       'totalPossibleDays', 'ewrCode', 'scenario', 'Gauge', 'pu']
     assert result.shape == (4, 16)
 
 def test_get_events_to_process(gauge_events):
     result = summarise_results.get_events_to_process(gauge_events)
     assert result == [ { "scenario" : 'observed',
-                          "gauge" : '419001',
+                          'Gauge' : '419001',
                           "pu" : 'Keepit to Boggabri',
                           "ewr": 'CF1_a',
                           "ewr_events" : {2010: [],
@@ -88,7 +88,7 @@ def test_get_events_to_process(gauge_events):
                             2014: [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]}
                             },
                        {"scenario" : 'observed',
-                          "gauge" : '419002',
+                          'Gauge' : '419002',
                           "pu" : 'Keepit to Boggabri',
                           "ewr": 'CF1_a',
                           "ewr_events" : {2010: [],
@@ -110,7 +110,7 @@ def test_process_yearly_events(event_item_to_process):
     result = summarise_results.process_yearly_events(**event_item_to_process)
     assert type(result) == pd.DataFrame
     assert result.to_dict() == {'scenario': {0: 'observed'},
-                                            'gauge': {0: '419001'},
+                                            'Gauge': {0: '419001'},
                                             'pu': {0: 'Keepit to Boggabri'},
                                             'ewrCode': {0: 'CF1_a'},
                                             'totalEvents': {0: 1},
@@ -122,7 +122,7 @@ def test_process_ewr_events_stats(event_items_to_process):
     assert type(result) == pd.DataFrame
     assert result.shape == (2, 7)
     assert result.to_dict() == {'scenario': {0: 'observed', 1: 'observed'},
-                                'gauge': {0: '419001', 1: '419002'},
+                                'Gauge': {0: '419001', 1: '419002'},
                                 'pu': {0: 'Keepit to Boggabri', 1: 'Keepit to Boggabri'},
                                 'ewrCode': {0: 'CF1_a', 1: 'CF1_a'},
                                 'totalEvents': {0: 1, 1: 1},
@@ -137,7 +137,7 @@ def test_summarise(detailed_results, gauge_events):
 def test_process_all_yearly_events(event_item_to_process):
     result = summarise_results.process_all_yearly_events(**event_item_to_process)
     assert result.to_dict() == {'scenario': {0: 'observed'},
-                                'gauge': {0: '419001'},
+                                'Gauge': {0: '419001'},
                                 'pu': {0: 'Keepit to Boggabri'},
                                 'ewr': {0: 'CF1_a'},
                                 'waterYear': {0: 2014},
@@ -149,7 +149,7 @@ def test_process_all_yearly_events(event_item_to_process):
 def test_process_all_events_results(event_items_to_process):
     result = summarise_results.process_all_events_results(event_items_to_process)
     assert result.to_dict() == {'scenario': {0: 'observed', 1: 'observed'},
-                                'gauge': {0: '419001', 1: '419002'},
+                                'Gauge': {0: '419001', 1: '419002'},
                                 'pu': {0: 'Keepit to Boggabri', 1: 'Keepit to Boggabri'},
                                 'ewr': {0: 'CF1_a', 1: 'CF1_a'},
                                 'waterYear': {0: 2014, 1: 2014},
@@ -167,7 +167,7 @@ def test_events_to_interevents(interEvent_item_to_process):
     all_interevents_df = summarise_results.events_to_interevents(start_date, end_date, all_events_df)
 
     expected_data = {'scenario': ['example_scenario']*12, 
-                    'gauge': ['409025']*8+['410007']*4, 
+                    'Gauge': ['409025']*8+['410007']*4, 
                     'pu': ['Murray River - Yarrawonga to Barmah']*8+['Upper Yanco Creek']*4, 
                     'State': ['NSW']*12,
                     'SWSDLName': ['New South Wales Murray']*8+['Murrumbidgee']*4,
@@ -185,7 +185,7 @@ def test_filter_successful_events(successfulEvent_item_to_process):
     all_interevents_df = summarise_results.filter_successful_events(all_events_df)
 
     expected_data = {'scenario': ['example_scenario']*6,
-            'gauge': ['409025']*5+['410007']*1, 
+            'Gauge': ['409025']*5+['410007']*1, 
             'pu': ['Murray River - Yarrawonga to Barmah']*5+['Upper Yanco Creek']*1, 
             'ewr': ['VF']*3+['LF2']*2+['SF2']*1,
             'waterYear': ['1901', '1901', '1904', '1901', '1904', '1904'], 
@@ -203,7 +203,7 @@ def test_filter_duplicate_start_dates(duplicate_event_item_to_process):
     df = summarise_results.filter_duplicate_start_dates(all_events_df)
 
     expected_data = {'scenario': ['example_scenario']*7,
-            'gauge': ['409025']*5+['410007']*2, 
+            'Gauge': ['409025']*5+['410007']*2, 
             'pu': ['Murray River - Yarrawonga to Barmah']*5+['Upper Yanco Creek']*2, 
             'ewr': ['VF']*2+['LF2']*3+['SF2']*2,
             'waterYear': ['1901', '1904', '1901', '1901', '1904','1901', '1904'], 

--- a/tests/test_summarise_results.py
+++ b/tests/test_summarise_results.py
@@ -25,12 +25,12 @@ def test_get_frequency():
     expected_f = 0
     assert f == expected_f
 
-@pytest.mark.parametrize("ewr,cols,expected",
+@pytest.mark.parametrize("Code,cols,expected",
         [("CF1", ["CF1_foo","CF1_bar","CF2_foo","CF2_bar"],["CF1_foo","CF1_bar"]),
         ("CF3", ["CF1_foo","CF1_bar","CF2_foo","CF2_bar"],[])],
 )
-def test_get_ewr_columns(ewr, cols, expected):
-    result = summarise_results.get_ewr_columns(ewr, cols)
+def test_get_ewr_columns(Code, cols, expected):
+    result = summarise_results.get_ewr_columns(Code, cols)
     assert result == expected
 
 @pytest.mark.parametrize("cols,expected",
@@ -52,11 +52,11 @@ def test_pu_dfs_to_process(detailed_results, pu_df):
     result = summarise_results.pu_dfs_to_process(detailed_results)
     assert result == [{ "scenario" : 'observed',
                          'Gauge' : '419001',
-                         "pu" : 'Keepit to Boggabri',
+                         "PlanningUnit" : 'Keepit to Boggabri',
                          "pu_df" : pu_df },
                          { "scenario" : 'observed',
                          'Gauge' : '419002',
-                         "pu" : 'Keepit to Boggabri',
+                         "PlanningUnit" : 'Keepit to Boggabri',
                          "pu_df" : pu_df }]
 
 def test_process_df(item_to_process):
@@ -64,7 +64,7 @@ def test_process_df(item_to_process):
     columns = result.columns.to_list()
     assert columns == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll','eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved', "rollingMaxInterEventAchieved", 'missingDays',
-       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu']
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'PlanningUnit']
     assert result.shape == (2, 16)
 
 def test_process_df_results(items_to_process):
@@ -72,15 +72,15 @@ def test_process_df_results(items_to_process):
     columns = result.columns.to_list()
     assert columns == ['Year', 'eventYears', 'numAchieved', 'numEvents', 'numEventsAll','eventLength', 'eventLengthAchieved',
        'totalEventDays', 'totalEventDaysAchieved', "rollingMaxInterEventAchieved", 'missingDays',
-       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'pu']
+       'totalPossibleDays', 'Code', 'scenario', 'Gauge', 'PlanningUnit']
     assert result.shape == (4, 16)
 
 def test_get_events_to_process(gauge_events):
     result = summarise_results.get_events_to_process(gauge_events)
     assert result == [ { "scenario" : 'observed',
                           'Gauge' : '419001',
-                          "pu" : 'Keepit to Boggabri',
-                          "ewr": 'CF1_a',
+                          "PlanningUnit" : 'Keepit to Boggabri',
+                          "Code": 'CF1_a',
                           "ewr_events" : {2010: [],
                             2011: [],
                             2012: [],
@@ -89,8 +89,8 @@ def test_get_events_to_process(gauge_events):
                             },
                        {"scenario" : 'observed',
                           'Gauge' : '419002',
-                          "pu" : 'Keepit to Boggabri',
-                          "ewr": 'CF1_a',
+                          "PlanningUnit" : 'Keepit to Boggabri',
+                          "Code": 'CF1_a',
                           "ewr_events" : {2010: [],
                             2011: [],
                             2012: [],
@@ -111,7 +111,7 @@ def test_process_yearly_events(event_item_to_process):
     assert type(result) == pd.DataFrame
     assert result.to_dict() == {'scenario': {0: 'observed'},
                                             'Gauge': {0: '419001'},
-                                            'pu': {0: 'Keepit to Boggabri'},
+                                            'PlanningUnit': {0: 'Keepit to Boggabri'},
                                             'Code': {0: 'CF1_a'},
                                             'totalEvents': {0: 1},
                                             'totalEventDays': {0: 6},
@@ -123,7 +123,7 @@ def test_process_ewr_events_stats(event_items_to_process):
     assert result.shape == (2, 7)
     assert result.to_dict() == {'scenario': {0: 'observed', 1: 'observed'},
                                 'Gauge': {0: '419001', 1: '419002'},
-                                'pu': {0: 'Keepit to Boggabri', 1: 'Keepit to Boggabri'},
+                                'PlanningUnit': {0: 'Keepit to Boggabri', 1: 'Keepit to Boggabri'},
                                 'Code': {0: 'CF1_a', 1: 'CF1_a'},
                                 'totalEvents': {0: 1, 1: 1},
                                 'totalEventDays': {0: 6, 1: 6},
@@ -138,8 +138,8 @@ def test_process_all_yearly_events(event_item_to_process):
     result = summarise_results.process_all_yearly_events(**event_item_to_process)
     assert result.to_dict() == {'scenario': {0: 'observed'},
                                 'Gauge': {0: '419001'},
-                                'pu': {0: 'Keepit to Boggabri'},
-                                'ewr': {0: 'CF1_a'},
+                                'PlanningUnit': {0: 'Keepit to Boggabri'},
+                                'Code': {0: 'CF1_a'},
                                 'waterYear': {0: 2014},
                                 'startDate': {0: date(2020, 11, 30)},
                                 'endDate': {0:   date(2020, 12, 5)},
@@ -150,8 +150,8 @@ def test_process_all_events_results(event_items_to_process):
     result = summarise_results.process_all_events_results(event_items_to_process)
     assert result.to_dict() == {'scenario': {0: 'observed', 1: 'observed'},
                                 'Gauge': {0: '419001', 1: '419002'},
-                                'pu': {0: 'Keepit to Boggabri', 1: 'Keepit to Boggabri'},
-                                'ewr': {0: 'CF1_a', 1: 'CF1_a'},
+                                'PlanningUnit': {0: 'Keepit to Boggabri', 1: 'Keepit to Boggabri'},
+                                'Code': {0: 'CF1_a', 1: 'CF1_a'},
                                 'waterYear': {0: 2014, 1: 2014},
                                 'startDate': {0: date(2020, 11, 30), 1: date(2020, 11, 30)},
                                 'endDate': {0: date(2020, 12, 5), 1: date(2020, 12, 5)},
@@ -168,10 +168,10 @@ def test_events_to_interevents(interEvent_item_to_process):
 
     expected_data = {'scenario': ['example_scenario']*12, 
                     'Gauge': ['409025']*8+['410007']*4, 
-                    'pu': ['Murray River - Yarrawonga to Barmah']*8+['Upper Yanco Creek']*4, 
+                    'PlanningUnit': ['Murray River - Yarrawonga to Barmah']*8+['Upper Yanco Creek']*4, 
                     'State': ['NSW']*12,
                     'SWSDLName': ['New South Wales Murray']*8+['Murrumbidgee']*4,
-                    'ewr': ['VF']*4+['LF2']*4+['SF2']*4,
+                    'Code': ['VF']*4+['LF2']*4+['SF2']*4,
                     'startDate': [date(1901,7,1), date(1901, 9, 1), date(1901, 12, 16), date(1904, 4, 1), date(1901,7,1), date(1901, 8, 26), date(1901, 12, 11), date(1904, 2, 16), date(1901, 7, 1), date(1901, 8, 16), date(1901, 12, 9), date(1904, 2, 6)],
                     'endDate': [date(1901, 7, 31), date(1901, 11, 30), date(1904, 1, 30), date(1905,6,30), date(1901, 8, 4), date(1901, 11, 30), date(1904, 1, 30), date(1905,6,30), date(1901, 8, 9), date(1901, 12, 5), date(1904, 1, 30), date(1905,6,30)],
                     'interEventLength': [31, 91, 776, 456, 35, 97, 781, 501, 40, 112, 783, 511]
@@ -186,8 +186,8 @@ def test_filter_successful_events(successfulEvent_item_to_process):
 
     expected_data = {'scenario': ['example_scenario']*6,
             'Gauge': ['409025']*5+['410007']*1, 
-            'pu': ['Murray River - Yarrawonga to Barmah']*5+['Upper Yanco Creek']*1, 
-            'ewr': ['VF']*3+['LF2']*2+['SF2']*1,
+            'PlanningUnit': ['Murray River - Yarrawonga to Barmah']*5+['Upper Yanco Creek']*1, 
+            'Code': ['VF']*3+['LF2']*2+['SF2']*1,
             'waterYear': ['1901', '1901', '1904', '1901', '1904', '1904'], 
             'startDate': [date(1901, 8, 1), date(1901, 12, 1), date(1904, 1, 31), date(1901, 8, 5), date(1904, 1, 31), date(1904, 1, 31)], 
             'endDate': [date(1901, 8, 31), date(1901, 12, 2), date(1904, 3, 31), date(1901, 8, 25), date(1904, 2, 15), date(1904, 3, 5)], 
@@ -204,8 +204,8 @@ def test_filter_duplicate_start_dates(duplicate_event_item_to_process):
 
     expected_data = {'scenario': ['example_scenario']*7,
             'Gauge': ['409025']*5+['410007']*2, 
-            'pu': ['Murray River - Yarrawonga to Barmah']*5+['Upper Yanco Creek']*2, 
-            'ewr': ['VF']*2+['LF2']*3+['SF2']*2,
+            'PlanningUnit': ['Murray River - Yarrawonga to Barmah']*5+['Upper Yanco Creek']*2, 
+            'Code': ['VF']*2+['LF2']*3+['SF2']*2,
             'waterYear': ['1901', '1904', '1901', '1901', '1904','1901', '1904'], 
             'startDate': [date(1901, 8, 1), date(1904, 1, 31), date(1901, 8, 5), date(1901, 12, 1), date(1904, 1, 31), date(1901, 8, 10), date(1901, 12, 6)], 
             'endDate': [date(1901, 12, 2), date(1904, 3, 31), date(1901, 8, 25), date(1901, 12, 9), date(1904, 2, 15), date(1901, 8, 15), date(1904, 3, 5)], 


### PR DESCRIPTION
If it is a parameter: ewr OR pu OR gauge
If it is the name of a column: "Code" OR "PlanningUnit" OR "Gauge"

The only exceptions to this are in summarise_results.py in which the functions process_df(), process_yearly_events() and process_all_yearly_events() use column names as variables. Because of how these functions are called elsewhere in the code, there isn't a quick fix to this, and we would need to adjust the functions that call them.
i.e. def process_df(... , Gauge:str, PlanningUnit:str, ...) instead of def process_df(... , gauge:str, pu:str, ...)
TODO: fix this.