### PR TITLE
Fix mask_dates zero handling and deterministic water year ordering

### DIFF
--- a/py_ewr/evaluate_EWRs.py
+++ b/py_ewr/evaluate_EWRs.py
@@ -148,7 +148,7 @@ def mask_dates(EWR_info: dict, input_df: pd.DataFrame) -> set:
         set: A set of dates from the dataframe that fall within the required date range
     
     '''
-    if pd.isna(EWR_info['start_day']) or pd.isna(EWR_info['end_day']):
+    if EWR_info['start_day'] in (None, 0) or pd.isna(EWR_info['start_day']) or EWR_info['end_day'] in (None, 0) or pd.isna(EWR_info['end_day']):
         # A month mask is required here as there are no day requirements:
         input_df_timeslice = get_month_mask(EWR_info['start_month'],
                                             EWR_info['end_month'],
@@ -4191,7 +4191,7 @@ def event_stats(df:pd.DataFrame, PU_df:pd.DataFrame, gauge:str, ewr:str, EWR_inf
 
     
     '''
-    unique_water_years = set(water_years)
+    unique_water_years = sorted(set(water_years))
     # Years with events
     years_with_events = get_event_years(EWR_info, events, unique_water_years)
 


### PR DESCRIPTION
## Summary
- **`mask_dates`**: Treat `start_day`/`end_day` values of `0` as missing (alongside `None`/`NaN`), so the function correctly falls back to month-only date masking. Previously, `pd.isna(0)` returned `False`, causing `0` values to bypass the month mask.
- **`event_stats`**: Use `sorted(set(water_years))` instead of `set(water_years)` to ensure deterministic iteration order, preventing inconsistent results across runs.

## Test plan
- [ ] Verify `mask_dates` correctly applies month-only masking when `start_day` or `end_day` is `0`
- [ ] Verify `event_stats` produces consistent, ordered results across multiple runs
- [ ] Run existing test suite to confirm no regressions

## Background

This was found when using the tool for FlowMER event evaluation. 
- **`mask_dates`** change was needed for long events over a calendar year, a baseflow in the Goulburn in particular.
- **`event_stats`** change was needed when plotting event success in particular years, successful flood year, 2022/23 for example, were not attributed to the right water year.
